### PR TITLE
Oliver's updates

### DIFF
--- a/p2719.md
+++ b/p2719.md
@@ -22,7 +22,7 @@ This paper proposes an extension to the way _new-expressions_ and _delete-expres
 deallocation function to provide the power of the in-class operator variant, which retains the knowledge of the type
 being allocated/deallocated, without requiring the intrusive definition of an in-class function. This is achieved by
 tweaking the search already performed by _new-expressions_ and _delete-expressions_ to also include a call to any free
-function `operator new` with a first parameter of `std::type_identity<T>`. The following describes (roughly) the search
+function `operator new` with an additional tag parameter of `std::type_identity<T>`. The following describes (roughly) the search
 process performed by the compiler before and after this paper:
 
 ::: cmptable
@@ -44,8 +44,33 @@ new (args...) T(...)
 
 // compiler checks:
 T::operator new(sizeof(T), args...) // (1)
-@[operator new(std::type_identity\<T\>, sizeof(T), args...)]{.add}@ // (2)
+@[operator new(sizeof(T), std::type_identity\<T\>, args...)]{.add}@ // (2)
 ::operator new(sizeof(T), args...)  // (3)
+```
+
+:::
+
+::: cmptable
+
+### Before
+```cpp
+// user writes:
+new (args...) T[n]
+
+// compiler checks:
+T::operator new[](sizeof(T), n, args...) // (1)
+::operator new[](sizeof(T), n, args...)  // (2)
+```
+
+### After
+```cpp
+// user writes:
+new (args...) T\[n\];
+
+// compiler checks:
+T::operator new\[\](sizeof(T), n, args...) // (1)
+@[operator new\[\](sizeof(T), n, std::type_identity\<T\>, args...)]{.add}@ // (2)
+::operator new\[\](sizeof(T), n, args...)  // (3)
 ```
 
 :::
@@ -69,8 +94,33 @@ delete ptr
 
 // compiler checks:
 T::operator delete(void-ptr) // (1)
-@[operator delete(std::type_identity\<T\>, ptr)]{.add}@ // (2)
+@[operator delete(void-ptr, std::type_identity\<T\>)]{.add}@ // (2)
 ::operator delete(void-ptr)  // (3)
+```
+
+:::
+
+::: cmptable
+
+### Before
+```cpp
+// user writes:
+delete [] obj
+
+// compiler checks:
+T::operator delete[](void-ptr) // (1)
+::operator delete[](void-ptr)  // (2)
+```
+
+### After
+```cpp
+// user writes:
+delete [] ptr
+
+// compiler checks:
+T::operator delete[](void-ptr) // (1)
+@[operator delete[](void-ptr, std::type_identity\<T\>)]{.add}@ // (2)
+::operator delete[](void-ptr)  // (3)
 ```
 
 :::
@@ -159,7 +209,7 @@ Assuming that the name lookup or the overload resolution for `T::operator new` f
 name lookup for a free function named `operator new` as-if we had the following expression:
 
 ```cpp
-operator new(std::type_identity<T>, sizeof(T), args...)
+operator new(sizeof(T), std::type_identity<T>, args...)
 ```
 
 In other words, the set of associated namespaces would include the `std` namespace (via `std::type_identity`), the associated
@@ -171,8 +221,8 @@ do in [expr.new#19](https://timsong-cpp.github.io/cppwp/n4950/expr.new#19), but 
 `std::type_identity` argument:
 
 ```cpp
-operator new(std::type_identity<T>, sizeof(T), args...)                   // first resolution attempt
-operator new(std::type_identity<T>, sizeof(T), std::align_val_t, args...) // second resolution attempt
+operator new(sizeof(T), std::type_identity<T>, args...)                   // first resolution attempt
+operator new(sizeof(T), std::align_val_t, std::type_identity<T>, args...) // second resolution attempt
 ```
 
 For a type with new-extended alignment, we simply reverse the order of these overload resolution attempts. If this overload
@@ -186,10 +236,11 @@ Delete expressions work in a way entirely analoguous to what is described above 
 ```cpp
 namespace lib {
   struct Foo { };
-  void* operator new(std::type_identity<Foo>, std::size_t); // (1)
 
   struct Foo2 { };
 }
+
+void* operator new(std::size_t, std::type_identity<Foo>); // (1)
 
 struct Bar {
   void* operator new(std::size_t); // (2)
@@ -243,13 +294,36 @@ In all cases, if we wanted this to remain ill-formed, we could either count on c
 case, or we could word the search process to say that if the overload resolution on `T::operator new` fails, the
 program is ill-formed and the search stops. This doesn't seem useful to me, but it's on the table.
 
-## Design choice: Order of arguments
+## Design choice: Should a templated operator delete be allowed as a usual allocation function
 
-Should `std::type_identity<T>` come before or after the `std::size_t` argument? We started with the size first and
-changed it because we felt it made it clearer that typed allocation was a "different kind of allocation function".
+3.7.4.2 states that a template function may not be considered a usual allocation function, this prevents general allocators from specifying a general type aware deallocation operator that can reflect the correct concrete type when invoking a deleting constructor. e.g.
 
-At the end of the day, we can pick either option and the author doesn't care strongly, but we should make sure that
-typed allocation and deallocation are consistent with each other.
+```cpp
+class Root {
+public:
+  template <typename T> static void *operator new(size_t, std::type_identity<T>);
+  template <typename T> static void operator delete(void *, std::type_identity<T>);
+};
+
+class SubclassA : public Root {
+};
+
+class SubclassB : public Root {
+  virtual ~SubclassB();
+};
+class SubclassC : public SubclassB {
+};
+
+int foo(SubclassA *a, SubclassB *b, SubclassB *actuallySubclassC) {
+  delete a; // The allocator would want Root::operator delete<SubclassA>(...) to be called
+  delete b; // The allocator would call the deleting virtual destructor, and expect this to invoke
+            // Root::operator delete<SubclassB>
+  delete c; // The allocator would call the deleting virtual destructor, and expect this to invoke
+            // Root::operator delete<SubclassC>
+}
+```
+
+Allowing a template delete operator to be considered a usual allocation function could result in previously ignored delete declarations being invoked. We could mitigate this risk by constraining the selection of template `usual` allocations to solely allow the typed allocation signatures - the existing selection rules for usual allocation functions already have strict parameter type restrictions on what is required for an allocation function to be usual so this is not wholly without precedence.
 
 ## Design choice: Template argument vs `std::type_identity`
 

--- a/p2719.md
+++ b/p2719.md
@@ -58,8 +58,8 @@ T::operator new(sizeof(T), args...) // (1)
 new (args...) T[n]
 
 // compiler checks:
-T::operator new[](sizeof(T), n, args...) // (1)
-::operator new[](sizeof(T), n, args...)  // (2)
+T::operator new[](n * sizeof(T), args...) // (1)
+::operator new[](n * sizeof(T), args...)  // (2)
 ```
 
 ### After
@@ -68,9 +68,9 @@ T::operator new[](sizeof(T), n, args...) // (1)
 new (args...) T\[n\];
 
 // compiler checks:
-T::operator new\[\](sizeof(T), n, args...) // (1)
-@[operator new\[\](sizeof(T), n, std::type_identity\<T\>, args...)]{.add}@ // (2)
-::operator new\[\](sizeof(T), n, args...)  // (3)
+T::operator new\[\](n * sizeof(T), args...) // (1)
+@[operator new\[\](n * sizeof(T), std::type_identity\<T\>, args...)]{.add}@ // (2)
+::operator new\[\](n * sizeof(T), args...)  // (3)
 ```
 
 :::
@@ -105,7 +105,7 @@ T::operator delete(void-ptr) // (1)
 ### Before
 ```cpp
 // user writes:
-delete [] obj
+delete[] ptr
 
 // compiler checks:
 T::operator delete[](void-ptr) // (1)
@@ -115,7 +115,7 @@ T::operator delete[](void-ptr) // (1)
 ### After
 ```cpp
 // user writes:
-delete [] ptr
+delete[] ptr
 
 // compiler checks:
 T::operator delete[](void-ptr) // (1)


### PR DESCRIPTION
Reordered the parameters to new and delete. There are enough explicit rules about the first and second parameter types for valid new and delete operators that placing the type_identity first that I think trying to use a different order just won't fly.

Added explicit examples for new[] and delete[] as their absence might imply that they aren't covered. We may want to just have an additional addendum saying something to the effect of "and so on for the aligned and sized variants".

I've added a note/design choice - for this to be usable to kalloc_type we need to be able to specify general operators new and delete, so they need to be templatized. The rules for resolving operator delete preclude picking up the templated delete as a usual delete operator which means that the untyped delete would be selected for at least the virtual deleting destructor.