### PR TITLE
Draft/p2719 updates

### DIFF
--- a/p2719.md
+++ b/p2719.md
@@ -50,6 +50,10 @@ resolution over the set of candidates in the following order
 
 ::: cmptable
 
+<!-- I'm really not sure how to present candidate resolution, i feel it's important to
+     explain new/delete don't behave as completely trivial function resolution but have
+     a unique "find the best set of implicit parameters first" step -->
+
 ### Before
 ```cpp
 Candidate(size_t, align_val_t, args...)
@@ -68,7 +72,7 @@ Candidate(size_t, args...)
 :::
 
 Resolution ordering for _delete-expressions_ matches that of _new-expressions_, only with minor changes to incorporate
-additional implicit parameters.
+additional implicit _destroying_ and _size_ parameters.
 
 :::
 
@@ -78,8 +82,6 @@ additional implicit parameters.
 - R1 (based on St-Louis feedback and implementation experience):
   - Simplified the lookup mechanism by removing the need to perform ADL
   - Allowed `std::type_identity` parameter in `operator new` defined at class scope for consistency
-  - OLIVER: TODO: Made the `std::type_identity<T>` argument first (OLIVER TODO: Explain why that templated operator new can exist today but requires std::size_t in the first position, so that would break existing code)
-  - OLIVER: TODO: Explain the difficulty with ADL taking into account placement args with mismatching new/delete, even though we don't do it anymore
   - LOUIS: TODO: Added justification for taking `std::type_identity<T>` instead of `T*` as a first argument.
   - LOUIS: TODO: Added explanation of what happens w.r.t. ODR and mismatched new/delete operators
   - LOUIS: TODO: Mention interactions with `std::allocator` and that we can resolve that separately
@@ -505,6 +507,30 @@ the concrete type at the point of invocation, the semantics of doing so don't me
 from those present in the existing destroying delete specification. As a result we believe that
 extending destroying delete to support subtype dispatch is a more general issue that is outside of
 the scope of this proposal. 
+
+## Design choice: ADL
+
+The initial proposal allowed the specification of type aware allocators in namespaces that could
+then be resolved via ADL. Upon further consideration this introduces a number of hazards to the
+language that are complex to resolve robustly and as a result we have dropped support for
+namespaced allocator declarations and removed the use of ADL from the proposal.
+
+The first problem is declarations discovered from ADL over placement arguments. For operator new
+these are not a problem, however the delete operator does not support placement arguments, so the
+search scope can be significantly different between `new (args) Type` and the subsequent
+`delete Object`.
+
+Our hope was that by allowing namespaced operators we would simplify the work of constraining for
+a library to constrain a custom allocator to just the types in that library, however there exist
+myriad mechanisms by which a simple namespace only constraint is unintentionally expanded, the most
+trivial of which is `new Namespace1::Type<Namespace2::Type>`. As a result a conscientious developer
+will always need to appropriately constrain their type aware API, even if they were scoped.
+
+As that work is functionally always required, the addition of ADL to the search phase does not
+meaningfully improve the developer experience, and it introduces a hazard wherein a developer is not
+aware that simply namespacing the declarations is insufficient - it will frequently appear to work
+as expected - whereas there is already a strong understanding of the work involved in exposing and
+overriding global allocation functions.
 
 # Suggested polls
 

--- a/p2719.md
+++ b/p2719.md
@@ -26,9 +26,7 @@ tag argument that allows the provision of the concrete type to `operator new` an
 creation of type-specific `operator new` and `operator delete` for types that cannot have intrusive class-scoped
 operators specified, and allows accurate type information to be provided when allocating subtypes.
 
-To add further convenience to this model, we propose allowing these type-aware interfaces to be namespace-scoped,
-and add an additional ADL lookup for new and delete operator based on the type being allocated. The following describes
-(roughly) the search process performed by the compiler before and after this paper:
+The following describes (roughly) the search process performed by the compiler before and after this paper:
 
 ::: cmptable
 
@@ -38,9 +36,8 @@ and add an additional ADL lookup for new and delete operator based on the type b
 new (args...) T(...)
 
 // compiler checks:
-{{DeclScope = (T specifies operator new) ? T : Global}}
-DeclSpace::operator new(sizeof(T), align_val_t(alignof(T)), args...) // (1)
-DeclSpace::operator new(sizeof(T), args...)  // (2)
+operator new(size_t, align_val_t, args...)
+operator new(size_t, args...)
 ```
 
 ### After
@@ -49,36 +46,10 @@ DeclSpace::operator new(sizeof(T), args...)  // (2)
 new (args...) T(...)
 
 // compiler checks:
-DeclSpace::operator new(std::type_identity<T>, sizeof(T), align_val_t(alignof(T)), args...) // (1)
-DeclSpace::operator new(std::type_identity<T>, sizeof(T)), args...) // (1)
-DeclSpace::operator new(sizeof(T), align_val_t(alignof(T)), args...) // (1)
-DeclSpace::operator new(sizeof(T), args...)  // (2)
-```
-
-:::
-
-::: cmptable
-
-### Before
-```cpp
-// TODO: Update remainder of examples
-// user writes:
-new (args...) T[n]
-
-// compiler checks:
-T::operator new[](n * sizeof(T), args...) // (1)
-::operator new[](n * sizeof(T), args...)  // (2)
-```
-
-### After
-```cpp
-// user writes:
-new (args...) T[n];
-
-// compiler checks:
-T::operator new[](n * sizeof(T), args...) // (1)
-@[operator new[](n * sizeof(T), std::type_identity<T>, args...)]{.add}@ // (2)
-::operator new[](n * sizeof(T), args...)  // (3)
+@[operator new(type_identity<T>, size_t, align_val_t, args...)]{.add}@
+@[operator new(type_identity<T>, size_t, args...)]{.add}@
+operator new(size_t, align_val_t, args...)
+operator new(size_t, args...)
 ```
 
 :::
@@ -91,10 +62,10 @@ T::operator new[](n * sizeof(T), args...) // (1)
 delete ptr
 
 // compiler checks:
-// TODO: Myriad align and size parameters
-{{DeclSpace = (T specifies operator new) ? T : Global + ADL_lookup(T)}}
-DeclSpace::operator delete(T*, destroying_tag_t)
-DeclSpace::operator delete(void-ptr)  // (2)
+// OLIVER: TODO: Add other overloads
+// OLIVER: TODO: Check how delete operators are prefered
+operator delete(T*, destroying_delete_t)
+operator delete(void-ptr)
 ```
 
 ### After
@@ -103,39 +74,11 @@ DeclSpace::operator delete(void-ptr)  // (2)
 delete ptr
 
 // compiler checks:
-// TODO: Myriad align and size parameters
-{{DeclSpace = (T specifies operator new) ? T : Global}}
-DeclSpace::operator delete(std::type_identity<T>, T*, destroying_tag_t)
-DeclSpace::operator delete(std::type_identity<T>, void-ptr)  // (2)
-DeclSpace::operator delete(T*, destroying_tag_t)
-DeclSpace::operator delete(void-ptr)  // (2)
-```
-
-:::
-
-::: cmptable
-
-### Before
-```cpp
-// TODO: Update these
-
-// user writes:
-delete[] ptr
-
-// compiler checks:
-T::operator delete[](void-ptr) // (1)
-::operator delete[](void-ptr)  // (2)
-```
-
-### After
-```cpp
-// user writes:
-delete[] ptr
-
-// compiler checks:
-T::operator delete[](void-ptr) // (1)
-@[operator delete[](void-ptr, std::type_identity<T>)]{.add}@ // (2)
-::operator delete[](void-ptr)  // (3)
+// OLIVER: TODO: Add other overloads
+@[operator delete(type_identity<T>, T*, destroying_delete_t)]{.add}@
+@[operator delete(type_identity<T>, void-ptr)]{.add}@
+operator delete(T*, destroying_tag_t)
+operator delete(void-ptr)
 ```
 
 :::
@@ -144,12 +87,15 @@ T::operator delete[](void-ptr) // (1)
 
 - R0: Initial version
 - R1 (based on St-Louis feedback and implementation experience):
-  - Simplified the lookup mechanism to avoid entangling overload resolution with name lookup
-  - Allowed `std::type_identity` parameter in `operator new` defined at class scope
-  - Modified mechanism to not take into account placement args for ADL (TODO: Explain why in Design section)
-  - Made the `std::type_identity<T>` argument first
-  - TODO: Added justification for taking `std::type_identity<T>` instead of `T*` as a first argument
-  - TODO: Added explanation of what happens w.r.t. ODR and mismatched new/delete operators
+  - Simplified the lookup mechanism by removing the need to perform ADL
+  - Allowed `std::type_identity` parameter in `operator new` defined at class scope for consistency
+  - OLIVER: TODO: Made the `std::type_identity<T>` argument first (OLIVER TODO: Explain why that templated operator new can exist today but requires std::size_t in the first position, so that would break existing code)
+  - OLIVER: TODO: Explain the difficulty with ADL taking into account placement args with mismatching new/delete, even though we don't do it anymore
+  - LOUIS: TODO: Added justification for taking `std::type_identity<T>` instead of `T*` as a first argument.
+  - LOUIS: TODO: Added explanation of what happens w.r.t. ODR and mismatched new/delete operators
+  - LOUIS: TODO: Mention interactions with `std::allocator` and that we can resolve that separately
+
+<!-- OLIVER TODO: Make sure it renders nicely -->
 
 # Motivation
 
@@ -223,12 +169,12 @@ To avoid potential conficts with existing code, this parameter is placed as the 
 the size or subject pointer. For such a declaration to be valid we require that the parameter be explicitly a specialization
 of `std::type_identity`, and not a fully dependent type.
 
-**terminology?**
+<!--
+Terminology question:
 i'm wanting to say these are correct:
 void* operator new(std::type_identity<Foo>, size_t, ...);
 template <typename T> void* operator new(std::type_identity<T>, size_t, ...);
 template <typename T> void* operator new(std::type_identity<Foo<T>>, size_t, ...);
-
 
 but these are not:
 
@@ -236,7 +182,7 @@ template <typename T> void* operator new(T, size_t, ...); // even if invoked wit
 template <typename T> struct S { void* operator new(T, size_t, ...); }; S<std::type_identity<int>>
 template <template<typename> typename T> void* operator new(T<int>, size_t, ...); // even if invoked with `operator new<std::type_identity>
 etc
-**end note**
+-->
 
 We will refer to operator new and delete declarations of this form as "type aware allocation operators".
 
@@ -260,10 +206,10 @@ the addition of the type_identity tag, with a higher priority than the existing 
 us the following overload resolution ordering for operator new:
 
 ```cpp
-1. NEW(type_identity<T>(), sizeof(T), align_val_t(alignof(T)), args...)
-2. NEW(type_identity<T>(), sizeof(T), args...)
-3. NEW(sizeof(T), align_val_t(alignof(T)), args...)
-4. NEW(sizeof(T), args...)
+1. NEW(type_identity<T>, size_t, align_val_t, args...)
+2. NEW(type_identity<T>, size_t, args...)
+3. NEW(size_t, align_val_t, args...)
+4. NEW(size_t, args...)
 ```
 
 When a constructor throws an exception, a cleanup call is made to `operator delete`. The semantics of this cleanup
@@ -274,24 +220,24 @@ Overload resolution for delete expressions is effectively the same, only with mi
 
 ```cpp
 1. If destroying delete is applicable:
-  1. DELETE(type_identity<T>(), <Destroying Type>*, destroying_delete_tag_t(), sizeof(T), align_val_t(alignof(T)))
-  2. DELETE(type_identity<T>(), <Destroying Type>*, destroying_delete_tag_t(), sizeof(T))
-  3. DELETE(type_identity<T>(), <Destroying Type>*, destroying_delete_tag_t())
-  4. DELETE(<Destroying Type>*, destroying_delete_tag_t(), sizeof(T), align_val_t(alignof(T)))
-  5. DELETE(<Destroying Type>*, destroying_delete_tag_t(), sizeof(T))
-  6. DELETE(<Destroying Type>*, destroying_delete_tag_t())
-2. DELETE(type_identity<T>(), void*, sizeof(T), align_val_t(alignof(T)))
-3. DELETE(type_identity<T>(), void*, sizeof(T))
-4. DELETE(type_identity<T>(), void*)
-5. DELETE(void*, sizeof(T), align_val_t(alignof(T)))
-6. DELETE(void*, sizeof(T))
+  1. DELETE(type_identity<T>, <Destroying Type>*, destroying_delete_t, size_t, align_val_t)
+  2. DELETE(type_identity<T>, <Destroying Type>*, destroying_delete_t, size_t)
+  3. DELETE(type_identity<T>, <Destroying Type>*, destroying_delete_t)
+  4. DELETE(<Destroying Type>*, destroying_delete_t, size_t, align_val_t)
+  5. DELETE(<Destroying Type>*, destroying_delete_t, size_t)
+  6. DELETE(<Destroying Type>*, destroying_delete_t)
+2. DELETE(type_identity<T>, void*, size_t, align_val_t)
+3. DELETE(type_identity<T>, void*, size_t)
+4. DELETE(type_identity<T>, void*)
+5. DELETE(void*, size_t, align_val_t)
+6. DELETE(void*, size_t)
 7. DELETE(void*)
 ```
 
 ## Example
 
 ```cpp
-// TODO: Update these examples
+// OLIVER: TODO: Update these examples
 namespace lib {
   struct Foo { };
   void* operator new(std::size_t, std::type_identity<Foo>); // (1)

--- a/p2719.md
+++ b/p2719.md
@@ -1,7 +1,7 @@
 ---
 title: "Type-aware allocation and deallocation functions"
 document: P2719R1
-date: 2024-10-11
+date: 2024-10-16
 audience: Evolution
 author:
   - name: Louis Dionne

--- a/p2719.md
+++ b/p2719.md
@@ -20,12 +20,9 @@ expression like `new T(...)` will use that allocation function. Otherwise, the g
 replaced by users in a type-agnostic way, by implementing `void* operator new(size_t)` and its variants. A similar
 mechanism exists for _delete-expressions_.
 
-This paper proposes an extension to the way _new-expressions_ and _delete-expressions_ select their allocation and
-deallocation function to provide the power of the in-class operator variant, which retains the knowledge of the type
-being allocated/deallocated, without requiring the intrusive definition of an in-class function. This is achieved by
-tweaking the search already performed by _new-expressions_ and _delete-expressions_ to also include a call to any free
-function `operator new` with an additional tag parameter of `std::type_identity<T>`. The following describes (roughly) the search
-process performed by the compiler before and after this paper:
+This paper proposes an extension to _new-expressions_ and _delete-expressions_ to provide the concrete type of an allocation or deallocation to the allocation functions. This is achieved via the addition of an additional tag argument of type `std::type_identity_t<TypeBeingAllocated>` that allows the provision of the concrete type to `operator new` and `oeprator delete`. This allows the addition of type specific implementations of `operator new` and `operator delete` for types that cannot have invasive class scoped allocators specified, and allows accurate type information to be provided when allocating subtypes.
+
+To add further convenience to these models, we also propose allowing these type aware interfaces to be namespace scoped, and add an additional ADL lookup for new and delete operator based on the type being allocated.
 
 ::: cmptable
 
@@ -34,9 +31,10 @@ process performed by the compiler before and after this paper:
 // user writes:
 new (args...) T(...)
 
-// compiler checks (in order):
-T::operator new(sizeof(T), args...)
-::operator new(sizeof(T), args...)
+// compiler checks:
+{{DeclScope = (T specifies operator new) ? T : Global}}
+DeclSpace::operator new(sizeof(T), align_val_t(alignof(T)), args...) // (1)
+DeclSpace::operator new(sizeof(T), args...)  // (2)
 ```
 
 ### After
@@ -44,35 +42,36 @@ T::operator new(sizeof(T), args...)
 // user writes:
 new (args...) T(...)
 
-// compiler checks (in order):
-T::operator new(sizeof(T), args...)
-@[operator\ new(sizeof(T),\ type_identity\<T\>{},\ args...)]{.add}@
-::operator new(sizeof(T), args...)
+// compiler checks:
+DeclSpace::operator new(std::type_identity\<T\>, sizeof(T), align_val_t(alignof(T)), args...) // (1)
+DeclSpace::operator new(std::type_identity\<T\>, sizeof(T)), args...) // (1)
+DeclSpace::operator new(sizeof(T), align_val_t(alignof(T)), args...) // (1)
+DeclSpace::operator new(sizeof(T), args...)  // (2)
 ```
 
 :::
 
 ::: cmptable
-
+// TODO: Update remainder of examples
 ### Before
 ```cpp
 // user writes:
 new (args...) T[n]
 
-// compiler checks (in order):
-T::operator new[](n*sizeof(T), args...)
-::operator new[](n*sizeof(T), args...)
+// compiler checks:
+T::operator new[](n * sizeof(T), args...) // (1)
+::operator new[](n * sizeof(T), args...)  // (2)
 ```
 
 ### After
 ```cpp
 // user writes:
-new (args...) T[n];
+new (args...) T\[n\];
 
-// compiler checks (in order):
-T::operator new[](n*sizeof(T), args...)
-@[operator\ new\[\](n*sizeof(T),\ type_identity\<T\>{},\ args...)]{.add}@
-::operator new[](n*sizeof(T), args...)
+// compiler checks:
+T::operator new\[\](n * sizeof(T), args...) // (1)
+@[operator new\[\](n * sizeof(T), std::type_identity\<T\>, args...)]{.add}@ // (2)
+::operator new\[\](n * sizeof(T), args...)  // (3)
 ```
 
 :::
@@ -82,11 +81,13 @@ T::operator new[](n*sizeof(T), args...)
 ### Before
 ```cpp
 // user writes:
-delete ptr
+delete obj
 
-// compiler checks (in order):
-T::operator delete(void-ptr)
-::operator delete(void-ptr)
+// compiler checks:
+// TODO: Myriad align and size parameters
+{{DeclSpace = (T specifies operator new) ? T : Global + ADL_lookup(T)}}
+DeclSpace::operator delete(T*, destroying_tag_t)
+DeclSpace::operator delete(void-ptr)  // (2)
 ```
 
 ### After
@@ -94,24 +95,27 @@ T::operator delete(void-ptr)
 // user writes:
 delete ptr
 
-// compiler checks (in order):
-T::operator delete(void-ptr)
-@[operator\ delete(void-ptr,\ type_identity\<T\>{})]{.add}@
-::operator delete(void-ptr)
+// compiler checks:
+// TODO: Myriad align and size parameters
+{{DeclSpace = (T specifies operator new) ? T : Global}}
+DeclSpace::operator delete(std::type_identity\<T\>, T*, destroying_tag_t)
+DeclSpace::operator delete(std::type_identity\<T\>, void-ptr)  // (2)
+DeclSpace::operator delete(T*, destroying_tag_t)
+DeclSpace::operator delete(void-ptr)  // (2)
 ```
 
 :::
 
 ::: cmptable
-
+// TODO: Update these
 ### Before
 ```cpp
 // user writes:
 delete[] ptr
 
-// compiler checks (in order):
-T::operator delete[](void-ptr)
-::operator delete[](void-ptr)
+// compiler checks:
+T::operator delete[](void-ptr) // (1)
+::operator delete[](void-ptr)  // (2)
 ```
 
 ### After
@@ -119,10 +123,10 @@ T::operator delete[](void-ptr)
 // user writes:
 delete[] ptr
 
-// compiler checks (in order):
-T::operator delete[](void-ptr)
-@[operator\ delete\[\](void-ptr,\ type_identity\<T\>{})]{.add}@
-::operator delete[](void-ptr)
+// compiler checks:
+T::operator delete[](void-ptr) // (1)
+@[operator delete[](void-ptr, std::type_identity\<T\>)]{.add}@ // (2)
+::operator delete[](void-ptr)  // (3)
 ```
 
 :::
@@ -132,13 +136,14 @@ T::operator delete[](void-ptr)
 Knowledge of the type being allocated in a _new-expression_ is necessary in order to achieve certain levels of flexibility
 when defining a custom allocation function. However, requiring an intrusive in-class definition to achieve this is not
 realistic in various circumstances, for example when wanting to customize allocation for types that are controlled by a
-third-party, or when customizing allocation for a very large number of types.
+third-party, or when customizing allocation for a very large number of types. Even when in-class definitions are an option, the existing specification does not provide a mechanism to support concrete type information when allocating and deallocating subtypes.
 
 In the wild, we often see code bases overriding the global (and untyped) `operator new` via the usual link-time mechanism
 and running into issues because they really only intended for their custom `operator new` to be used within their own code,
 not by all the code in their process. We also run into issues where multiple libraries attempt to replace the global
-`operator new` and end up with a complex ODR violation bug. The simple change proposed by this paper provides a way for
-most code bases to achieve what they _actually_ want, which is to override `operator new` for a family of types that they
+`operator new` and end up with a complex ODR violation bug. 
+
+The changes proposed by this paper provide a mechanism for code bases to implement smarter and more secure allocators, and to more easily implement what they _actually_ want, which is to override `operator new` for a family of types that they
 control without overriding it for the whole process. The overriding also happens at compile-time instead of link-time, which
 is both supported by all known implementations (unlike link-time) and better understood by users than e.g. weak definitions.
 
@@ -189,66 +194,50 @@ or without a `size_t` parameter depending on whether the considered `operator de
 
 # Proposal
 
-Our proposal essentially adds a new step in the resolution above that also considers a free function `operator new`
-after it considers a member `T::operator new`, but before the global `::operator new`. That free function is called as
-```c++
-operator new(sizeof(T), std::type_identity<T>{}, placement-args...)
-```
-In particular, this means that it triggers ADL, which allows defining such an operator in e.g. a custom namespace.
-We mostly discuss `operator new` below, but `operator new[]`, `operator delete` and `operator delete[]` are all
-handled analogously.
+This proposal adds a new implicit tag argument of type `type_identity_t<T>` to `operator new` and `operator delete` that is incorporated into the existing declaration preference logic with a higher priority than existing implicit parameters.
 
-## Wording approach
+To effectively support this new tag it is necessary to update the definition of a usual deallocation function ([basic.stc.dynamic.deallocation]) to:
 
-This proposal is best explained as two distinct changes to the existing rules explained above. First, observe how we
-currently perform name lookup first to fix the name we're using (either `T::operator new` or `::operator new`), and
-then perform overload resolution to find the best candidate given that name. This needs to change because if we introduce
-a free function in the mix that is found by ADL, we could often end up finding that free function as the result of name
-lookup. However, the mere presence of such a free function doesn't guarantee at all that it is a viable candidate given
-the arguments we have (for example if the free function merely happened to be in one of the namespaces we looked in). As
-a result, we could often end up in a situtation where `new Foo(...)` fails during overload resolution simply because a
-non-viable `operator new` free function was located in one of `Foo`'s associated namespaces.
+* Allow an additional parameter preceding the pointer argument of type `std::type_identity_t<T>`
 
-Consequently, the first change we need to make is to perform name lookup for `T::operator new`, and if found, then perform
-overload resolution on that name immediately. If overload resolution fails, then go on to the next candidate (which is
-`::operator new`) and perform overload resolution on that name. This change can be seen as a relaxation of the current
-rules and cannot affect any existing valid program. Indeed, code where `T::operator new` is currently selected but where
-overload resolution fails actually doesn't compile today, since the compiler falls flat after failing to perform overload
-resolution. After this change, such code would now fall back to trying overload resolution on `::operator new`, which might
-succeed.
+* The function may have template parameters
+  * Only the first parameter may have a dependent type
+  * The parameter must be a specialization of std::type_identity_t
 
-The second change we need to make is the addition of a new step in the search, between `T::operator new` and `::operator new`.
-Assuming that the name lookup or the overload resolution for `T::operator new` fails, we would now perform an argument-dependent
-name lookup for a free function named `operator new` as-if we had the following expression:
+Currently during operator resolution, if no in-class declaration is discovered we continue our search in the global scope. In our proposal we now also include an ADL lookup derived from the static type being allocated or deallocated as part of the process for finding free declarations of these operators.
+
+Once a set of candidate declarations has been found we perform the same priorities overload resolution steps, only with the addition of the type_identity tag, with a higher priority than the existing size and alignment parameters. This gives us the following overload resolution ordering for operator new:
 
 ```cpp
-operator new(sizeof(T), std::type_identity<T>{}, args...)
+1. NEW(type_identity<T>(), sizeof(T), align_val_t(alignof(T)), args...)
+2. NEW(type_identity<T>(), sizeof(T), args...)
+3. NEW(sizeof(T), align_val_t(alignof(T)), args...)
+4. NEW(sizeof(T), args...)
 ```
 
-In other words, the set of associated namespaces would include the `std` namespace (via `std::type_identity`), the associated
-namespaces of `T` (by virtue of the template parameter of `std::type_identity`), and that of any other provided placement-arguments.
-In particular, note that this may or may not include the global namespace.
+When a constructor throws an exception, a cleanup call is made to `operator delete`. The semantics of this cleanup resolution remain essentially the same, the only difference being that the `operator delete` selected during overload resolution must have the same type awareness as the preceding `operator new` or the program is considered ill formed.
 
-If this name lookup succeeds, we would perform overload resolution on this function in a way similar to what we currently
-do in [expr.new#19](https://timsong-cpp.github.io/cppwp/n4950/expr.new#19), but tweaked to take into account the
-`std::type_identity` argument:
+Overload resolution for delete expressions is effectively the same, only with minor variations on parameter types
 
 ```cpp
-// first resolution attempt
-operator new(sizeof(T), std::type_identity<T>{}, args...)
-
-// second resolution attempt
-operator new(sizeof(T), std::align_val_t(alignof(T)), std::type_identity<T>{}, args...)
+1. If destroying delete is applicable:
+  1. DELETE(type_identity<T>(), <Destroying Type>*, destroying_delete_tag_t(), sizeof(T), align_val_t(alignof(T)))
+  2. DELETE(type_identity<T>(), <Destroying Type>*, destroying_delete_tag_t(), sizeof(T))
+  3. DELETE(type_identity<T>(), <Destroying Type>*, destroying_delete_tag_t())
+  4. DELETE(<Destroying Type>*, destroying_delete_tag_t(), sizeof(T), align_val_t(alignof(T)))
+  5. DELETE(<Destroying Type>*, destroying_delete_tag_t(), sizeof(T))
+  6. DELETE(<Destroying Type>*, destroying_delete_tag_t())
+2. DELETE(type_identity<T>(), void*, sizeof(T), align_val_t(alignof(T)))
+3. DELETE(type_identity<T>(), void*, sizeof(T))
+4. DELETE(type_identity<T>(), void*)
+5. DELETE(void*, sizeof(T), align_val_t(alignof(T)))
+6. DELETE(void*, sizeof(T))
+7. DELETE(void*)
 ```
-
-For a type with new-extended alignment, we simply reverse the order of these overload resolution attempts. If this overload
-resolution fails, we would then move on to the next candidate found by name lookup, which is `::operator new`, and we would
-perform the usual overload resolution on it.
-
-Delete expressions or array new/delete expressions work in a way entirely analoguous to what is described above for single-object
-new-expressions.
 
 ## Example
+
+// TODO: Update these examples
 
 ```cpp
 namespace lib {
@@ -257,6 +246,8 @@ namespace lib {
 
   struct Foo2 { };
 }
+
+void* operator new(std::type_identity<Foo>, std::size_t); // (1)
 
 struct Bar {
   static void* operator new(std::size_t); // (2)
@@ -282,6 +273,8 @@ type-aware free function `operator new` variants in the standard library at this
 investigated in the future.
 
 ## Design choice: Order of arguments
+
+** [oliver] NOTE: i think we should switch to type_identity first as it ensures existing code cannot conflict**
 
 When writing this paper, we went back and forth of the order of arguments. This paper proposes:
 
@@ -317,7 +310,7 @@ operator new<T>(sizeof(T), args...)
 ```
 
 The only difference here is that we're not passing `std::type_identity` as a first argument and we are passing
-it as a template argument instead. Unfortunately, this has two problems. First, this doesn't allow ADL to kick
+it as a template argument instead. Unfortunately, this has a number of problems. First, this doesn't allow ADL to kick
 in, severely reducing the flexibility for defining the operator. The second problem is that existing code is
 allowed to have defined a global `operator new` like so:
 
@@ -332,22 +325,7 @@ result would be that the first template argument is explicitly provided by the c
 substitution failure (that is acceptable) or in a valid function call triggering an implicit conversion to the
 now-explicitly-provided first template argument, which would change the meaning of valid programs.
 
-## Design choice: No `std::type_identity` for `operator delete`
-
-We could perhaps simplify the design for delete-expressions by passing the type of the object directly:
-
-```cpp
-DELETE(static_cast<T*>(ptr), std::destroying_delete)
-DELETE(static_cast<T*>(ptr), std::destroying_delete, std::align_val_t(alignof(T)))
-@[DELETE(static_cast<T*>(ptr))]{.add}@
-DELETE(static_cast<void*>(ptr))
-@[DELETE(static_cast<T*>(ptr), std::align_val_t(alignof(T)))]{.add}@
-DELETE(static_cast<void*>(ptr), std::align_val_t(alignof(T)))
-```
-
-However, we believe that having using a tag type makes it clearer that typed deallocation functions do not destroy
-the object, and this also allows keeping the `operator delete` call consistent with the `operator new` call, which
-is a nice property.
+Finally, without this tag parameter it is not possible to distinguish a template type aware allocator from any other templated operator. This distinction is necessary for the semantics of new and delete in a number of contexts, especially the concept of a "usual deallocation function".
 
 ## Is the current name lookup for `T::operator new` done this way on purpose?
 

--- a/p2719.md
+++ b/p2719.md
@@ -20,9 +20,15 @@ expression like `new T(...)` will use that allocation function. Otherwise, the g
 replaced by users in a type-agnostic way, by implementing `void* operator new(size_t)` and its variants. A similar
 mechanism exists for _delete-expressions_.
 
-This paper proposes an extension to _new-expressions_ and _delete-expressions_ to provide the concrete type of an allocation or deallocation to the allocation functions. This is achieved via the addition of an additional tag argument of type `std::type_identity_t<TypeBeingAllocated>` that allows the provision of the concrete type to `operator new` and `oeprator delete`. This allows the addition of type specific implementations of `operator new` and `operator delete` for types that cannot have invasive class scoped allocators specified, and allows accurate type information to be provided when allocating subtypes.
+This paper proposes an extension to _new-expressions_ and _delete-expressions_ to provide the concrete type of an
+allocation or deallocation to the allocation functions. This is achieved via the addition of an additional tag argument
+of type `std::type_identity_t<TypeBeingAllocated>` that allows the provision of the concrete type to `operator new` and
+`oeprator delete`. This allows the addition of type specific implementations of `operator new` and `operator delete` for
+types that cannot have invasive class scoped allocators specified, and allows accurate type information to be provided
+when allocating subtypes.
 
-To add further convenience to these models, we also propose allowing these type aware interfaces to be namespace scoped, and add an additional ADL lookup for new and delete operator based on the type being allocated.
+To add further convenience to these models, we also propose allowing these type aware interfaces to be namespace scoped,
+and add an additional ADL lookup for new and delete operator based on the type being allocated.
 
 ::: cmptable
 
@@ -136,14 +142,17 @@ T::operator delete[](void-ptr) // (1)
 Knowledge of the type being allocated in a _new-expression_ is necessary in order to achieve certain levels of flexibility
 when defining a custom allocation function. However, requiring an intrusive in-class definition to achieve this is not
 realistic in various circumstances, for example when wanting to customize allocation for types that are controlled by a
-third-party, or when customizing allocation for a very large number of types. Even when in-class definitions are an option, the existing specification does not provide a mechanism to support concrete type information when allocating and deallocating subtypes.
+third-party, or when customizing allocation for a very large number of types. Even when in-class definitions are an option,
+the existing specification does not provide a mechanism to support concrete type information when allocating and deallocating
+subtypes.
 
 In the wild, we often see code bases overriding the global (and untyped) `operator new` via the usual link-time mechanism
 and running into issues because they really only intended for their custom `operator new` to be used within their own code,
 not by all the code in their process. We also run into issues where multiple libraries attempt to replace the global
-`operator new` and end up with a complex ODR violation bug. 
+`operator new` and end up with a complex ODR violation bug.
 
-The changes proposed by this paper provide a mechanism for code bases to implement smarter and more secure allocators, and to more easily implement what they _actually_ want, which is to override `operator new` for a family of types that they
+The changes proposed by this paper provide a mechanism for code bases to implement smarter and more secure allocators,
+and to more easily implement what they _actually_ want, which is to override `operator new` for a family of types that they
 control without overriding it for the whole process. The overriding also happens at compile-time instead of link-time, which
 is both supported by all known implementations (unlike link-time) and better understood by users than e.g. weak definitions.
 
@@ -194,7 +203,11 @@ or without a `size_t` parameter depending on whether the considered `operator de
 
 # Proposal
 
-This proposal adds a new implicit tag argument of type `type_identity_t<T>` to `operator new` and `operator delete` that is incorporated into the existing declaration preference logic with a higher priority than existing implicit parameters. To avoid potential conficts with existing code, this parameter is placed as the first argument to the operator, preceding the size or subject pointer. For such a declaration to be valid we require that the parameter be explicitly a specialization of `std::type_identity_t`, and not a fully dependent type.
+This proposal adds a new implicit tag argument of type `type_identity_t<T>` to `operator new` and `operator delete` that
+is incorporated into the existing declaration preference logic with a higher priority than existing implicit parameters.
+To avoid potential conficts with existing code, this parameter is placed as the first argument to the operator, preceding
+the size or subject pointer. For such a declaration to be valid we require that the parameter be explicitly a specialization
+of `std::type_identity_t`, and not a fully dependent type.
 
 **terminology?**
 i'm wanting to say these are correct:
@@ -213,10 +226,14 @@ etc
 
 We will refer to operator new and delete declarations of this form as "type aware allocation operators".
 
-To reduce leakage into the global scope, this proposal now allows type aware allocation operators to be declared within a namespace. **Note: i feel we should be able to specify semantics such that `new X` and `delete someX` require the resolved operator new and delete come from the same scope as at least a basic correctness guard**
+To reduce leakage into the global scope, this proposal now allows type aware allocation operators to be declared within
+a namespace. **Note: i feel we should be able to specify semantics such that `new X` and `delete someX` require the
+resolved operator new and delete come from the same scope as at least a basic correctness guard**
 
 
-Currently during operator resolution, if no in-class declaration is discovered we continue our search in the global scope. In our proposal if no in-class declaration of the requested operator is found we replace the current global scope look up with an ADL lookup over the implicit parameters. 
+Currently during operator resolution, if no in-class declaration is discovered we continue our search in the global scope.
+In our proposal if no in-class declaration of the requested operator is found we replace the current global scope look up
+with an ADL lookup over the implicit parameters.
 
 
 To effectively support this new tag it is necessary to update the definition of a usual deallocation function ([basic.stc.dynamic.deallocation]) to:
@@ -224,7 +241,9 @@ To effectively support this new tag it is necessary to update the definition of 
 * Allow type aware allocation operators. This means allowing the type_identity_t parameter, and updating the current spec text to allow for the change in later parameter positions
 * Allow the operator to have template arguments, as long as the only the first parameter is dependent, and it is type aware operator.
 
-Once a set of candidate declarations has been found we perform the same priorities overload resolution steps, only with the addition of the type_identity tag, with a higher priority than the existing size and alignment parameters. This gives us the following overload resolution ordering for operator new:
+Once a set of candidate declarations has been found we perform the same priorities overload resolution steps, only with
+the addition of the type_identity tag, with a higher priority than the existing size and alignment parameters. This gives
+us the following overload resolution ordering for operator new:
 
 ```cpp
 1. NEW(type_identity<T>(), sizeof(T), align_val_t(alignof(T)), args...)
@@ -233,7 +252,9 @@ Once a set of candidate declarations has been found we perform the same prioriti
 4. NEW(sizeof(T), args...)
 ```
 
-When a constructor throws an exception, a cleanup call is made to `operator delete`. The semantics of this cleanup resolution remain essentially the same, the only difference being that the `operator delete` selected during overload resolution must have the same type awareness as the preceding `operator new` or the program is considered ill formed.
+When a constructor throws an exception, a cleanup call is made to `operator delete`. The semantics of this cleanup
+resolution remain essentially the same, the only difference being that the `operator delete` selected during overload
+resolution must have the same type awareness as the preceding `operator new` or the program is considered ill formed.
 
 Overload resolution for delete expressions is effectively the same, only with minor variations on parameter types
 
@@ -343,7 +364,9 @@ result would be that the first template argument is explicitly provided by the c
 substitution failure (that is acceptable) or in a valid function call triggering an implicit conversion to the
 now-explicitly-provided first template argument, which would change the meaning of valid programs.
 
-Finally, without this tag parameter it is not possible to distinguish a template type aware allocator from any other templated operator. This distinction is necessary for the semantics of new and delete in a number of contexts, especially the concept of a "usual deallocation function".
+Finally, without this tag parameter it is not possible to distinguish a template type aware allocator from any other
+templated operator. This distinction is necessary for the semantics of new and delete in a number of contexts, especially
+the concept of a "usual deallocation function".
 
 ## Is the current name lookup for `T::operator new` done this way on purpose?
 

--- a/p2719.md
+++ b/p2719.md
@@ -22,7 +22,7 @@ mechanism exists for _delete-expressions_.
 
 This paper proposes an extension to _new-expressions_ and _delete-expressions_ to provide the concrete type of an
 allocation or deallocation to the allocation functions. This is achieved via the addition of an additional tag argument
-of type `std::type_identity_t<TypeBeingAllocated>` that allows the provision of the concrete type to `operator new` and
+of type `std::type_identity<TypeBeingAllocated>` that allows the provision of the concrete type to `operator new` and
 `oeprator delete`. This allows the addition of type specific implementations of `operator new` and `operator delete` for
 types that cannot have invasive class scoped allocators specified, and allows accurate type information to be provided
 when allocating subtypes.
@@ -203,24 +203,24 @@ or without a `size_t` parameter depending on whether the considered `operator de
 
 # Proposal
 
-This proposal adds a new implicit tag argument of type `type_identity_t<T>` to `operator new` and `operator delete` that
+This proposal adds a new implicit tag argument of type `std::type_identity<T>` to `operator new` and `operator delete` that
 is incorporated into the existing declaration preference logic with a higher priority than existing implicit parameters.
 To avoid potential conficts with existing code, this parameter is placed as the first argument to the operator, preceding
 the size or subject pointer. For such a declaration to be valid we require that the parameter be explicitly a specialization
-of `std::type_identity_t`, and not a fully dependent type.
+of `std::type_identity`, and not a fully dependent type.
 
 **terminology?**
 i'm wanting to say these are correct:
-void* operator new(std::type_identity_t<Foo>, size_t, ...);
-template <typename T> void* operator new(std::type_identity_t<T>, size_t, ...);
-template <typename T> void* operator new(std::type_identity_t<Foo<T>>, size_t, ...);
+void* operator new(std::type_identity<Foo>, size_t, ...);
+template <typename T> void* operator new(std::type_identity<T>, size_t, ...);
+template <typename T> void* operator new(std::type_identity<Foo<T>>, size_t, ...);
 
 
 but these are not:
 
-template <typename T> void* operator new(T, size_t, ...); // even if invoked with `operator new<type_identity_t<int>>`
-template <typename T> struct S { void* operator new(T, size_t, ...); }; S<std::type_identity_t<int>>
-template <template<typename> typename T> void* operator new(T<int>, size_t, ...); // even if invoked with `operator new<std::type_identity_t>
+template <typename T> void* operator new(T, size_t, ...); // even if invoked with `operator new<type_identity<int>>`
+template <typename T> struct S { void* operator new(T, size_t, ...); }; S<std::type_identity<int>>
+template <template<typename> typename T> void* operator new(T<int>, size_t, ...); // even if invoked with `operator new<std::type_identity>
 etc
 **end note**
 
@@ -238,7 +238,7 @@ with an ADL lookup over the implicit parameters.
 
 To effectively support this new tag it is necessary to update the definition of a usual deallocation function ([basic.stc.dynamic.deallocation]) to:
 
-* Allow type aware allocation operators. This means allowing the type_identity_t parameter, and updating the current spec text to allow for the change in later parameter positions
+* Allow type aware allocation operators. This means allowing the `std::type_identity` parameter, and updating the current spec text to allow for the change in later parameter positions
 * Allow the operator to have template arguments, as long as the only the first parameter is dependent, and it is type aware operator.
 
 Once a set of candidate declarations has been found we perform the same priorities overload resolution steps, only with
@@ -350,8 +350,8 @@ operator new<T>(sizeof(T), args...)
 
 The only difference here is that we're not passing `std::type_identity` as a first argument and we are passing
 it as a template argument instead. Unfortunately, this has a number of problems. First, this doesn't allow ADL to kick
-in, severely reducing the flexibility for defining the operator. The second problem is that existing code is
-allowed to have defined a global `operator new` like so:
+in, severely reducing the flexibility for defining the operator. Another problem is that existing code is allowed to
+have defined a global `operator new` like so:
 
 ```cpp
 template <class ...Args>

--- a/p2719.md
+++ b/p2719.md
@@ -194,17 +194,35 @@ or without a `size_t` parameter depending on whether the considered `operator de
 
 # Proposal
 
-This proposal adds a new implicit tag argument of type `type_identity_t<T>` to `operator new` and `operator delete` that is incorporated into the existing declaration preference logic with a higher priority than existing implicit parameters.
+This proposal adds a new implicit tag argument of type `type_identity_t<T>` to `operator new` and `operator delete` that is incorporated into the existing declaration preference logic with a higher priority than existing implicit parameters. To avoid potential conficts with existing code, this parameter is placed as the first argument to the operator, preceding the size or subject pointer. For such a declaration to be valid we require that the parameter be explicitly a specialization of `std::type_identity_t`, and not a fully dependent type.
+
+**terminology?**
+i'm wanting to say these are correct:
+void* operator new(std::type_identity_t<Foo>, size_t, ...);
+template <typename T> void* operator new(std::type_identity_t<T>, size_t, ...);
+template <typename T> void* operator new(std::type_identity_t<Foo<T>>, size_t, ...);
+
+
+but these are not:
+
+template <typename T> void* operator new(T, size_t, ...); // even if invoked with `operator new<type_identity_t<int>>`
+template <typename T> struct S { void* operator new(T, size_t, ...); }; S<std::type_identity_t<int>>
+template <template<typename> typename T> void* operator new(T<int>, size_t, ...); // even if invoked with `operator new<std::type_identity_t>
+etc
+**end note**
+
+We will refer to operator new and delete declarations of this form as "type aware allocation operators".
+
+To reduce leakage into the global scope, this proposal now allows type aware allocation operators to be declared within a namespace. **Note: i feel we should be able to specify semantics such that `new X` and `delete someX` require the resolved operator new and delete come from the same scope as at least a basic correctness guard**
+
+
+Currently during operator resolution, if no in-class declaration is discovered we continue our search in the global scope. In our proposal if no in-class declaration of the requested operator is found we replace the current global scope look up with an ADL lookup over the implicit parameters. 
+
 
 To effectively support this new tag it is necessary to update the definition of a usual deallocation function ([basic.stc.dynamic.deallocation]) to:
 
-* Allow an additional parameter preceding the pointer argument of type `std::type_identity_t<T>`
-
-* The function may have template parameters
-  * Only the first parameter may have a dependent type
-  * The parameter must be a specialization of std::type_identity_t
-
-Currently during operator resolution, if no in-class declaration is discovered we continue our search in the global scope. In our proposal we now also include an ADL lookup derived from the static type being allocated or deallocated as part of the process for finding free declarations of these operators.
+* Allow type aware allocation operators. This means allowing the type_identity_t parameter, and updating the current spec text to allow for the change in later parameter positions
+* Allow the operator to have template arguments, as long as the only the first parameter is dependent, and it is type aware operator.
 
 Once a set of candidate declarations has been found we perform the same priorities overload resolution steps, only with the addition of the type_identity tag, with a higher priority than the existing size and alignment parameters. This gives us the following overload resolution ordering for operator new:
 

--- a/p2719.md
+++ b/p2719.md
@@ -38,11 +38,11 @@ interesting:
 
 ```cpp
 template <class T>
-  requires has_type_segregation_requirement<T>
+  requires usable_with_custom_allocator<T>
 void* operator new(std::type_identity<T>, std::size_t n) { ... }
 
 template <class T>
-  requires has_type_segregation_requirement<T>
+  requires usable_with_custom_allocator<T>
 void operator delete(std::type_identity<T>, void* ptr) { ... }
 ```
 
@@ -52,9 +52,10 @@ void operator delete(std::type_identity<T>, void* ptr) { ... }
 - R1 (based on St-Louis feedback and implementation experience):
   - Simplified the lookup mechanism by removing the need to perform ADL
   - Allowed `std::type_identity` parameter for in-class `T::operator new` for consistency
-  - LOUIS: TODO: Added justification for taking `std::type_identity<T>` instead of `T*` as a first argument.
+  - Added justification for taking `std::type_identity<T>` instead of `T*` as a first argument.
   - LOUIS: TODO: Added explanation of what happens w.r.t. ODR and mismatched new/delete operators
   - LOUIS: TODO: Mention interactions with `std::allocator` and that we can resolve that separately
+  - Added justification for not allowing type-aware destroying delete
 
 # Motivation
 
@@ -132,14 +133,20 @@ To avoid conficts with existing code, this parameter is placed as the first argu
 subject pointer. To avoid the complexities of ADL, this proposal does not change any of the _name lookup_ rules associated
 to _new_ and _delete_ expressions: it only changes the overload resolution that happens once a name has been found.
 
+For the declaration of a type aware [de]allocation operator to be valid, we explicitly require that the parameter be a
+(potentially dependent) specialization of `std::type_identity`, but not a fully dependent type. In other words, the
+compiler must be able to tell that the first parameter is of the form `std::type_identity<T>` at the time of parsing
+the declaration, but before the declaration has been instantiated in the case of a template. This is analogous to the
+current behavior where we require specific concrete types in the parameter list even in dependent contexts.
+
 Once a set of candidate declarations has been found we perform the same prioritized overload resolution steps,
 only with the addition of `std::type_identity<T>`, with a higher priority than the existing size and alignment
 parameters. For illustration, here is how overload resolution changes (`NEW` is the set of candidates found by
 name lookup for `operator new`, and `DELETE` is the equivalent for `operator delete`):
 
-::: cmptable
+If the user writes `new T(...)`, the compiler checks (in order):
 
-> User writes `new T(...)`, compiler checks (in order):
+::: cmptable
 
 ### Before
 
@@ -174,15 +181,15 @@ NEW(size_t)
 
 :::
 
-::: cmptable
+If the user writes `delete ptr`, the compiler checks (in order):
 
-> User writes `delete ptr`, compiler checks (in order):
+::: cmptable
 
 ### Before
 
 ```cpp
 // assuming T not overaligned
-DELETE(T*, destroying_delete_t, ...)
+DELETE(DefiningClass*, destroying_delete_t, ...)
 DELETE(void*, size_t)
 DELETE(void*)
 ```
@@ -191,7 +198,7 @@ DELETE(void*)
 
 ```cpp
 // assuming T not overaligned
-DELETE(T*, destroying_delete_t, ...)
+DELETE(DefiningClass*, destroying_delete_t, ...)
 DELETE(type_identity<T>, void*, size_t)
 DELETE(type_identity<T>, void*)
 DELETE(void*, size_t)
@@ -202,7 +209,7 @@ DELETE(void*)
 
 ```cpp
 // assuming T overaligned
-DELETE(T*, destroying_delete_t, ...)
+DELETE(DefiningClass*, destroying_delete_t, ...)
 DELETE(void*, size_t, align_val_t)
 DELETE(void*, align_val_t)
 DELETE(void*)
@@ -210,7 +217,7 @@ DELETE(void*)
 
 ```cpp
 // assuming T overaligned
-DELETE(T*, destroying_delete_t, ...)
+DELETE(DefiningClass*, destroying_delete_t, ...)
 DELETE(type_identity<T>, void*, size_t, align_val_t)
 DELETE(type_identity<T>, void*, align_val_t)
 DELETE(type_identity<T>, void*)
@@ -227,8 +234,6 @@ according to usual rules for overload resolution.
 When a constructor throws an exception, a call to `operator delete` is made to clean up. Overload resolution for this
 call remains essentially the same, the only difference being that the selected `operator delete` must have the same
 type-awareness as the preceding `operator new` or the program is considered ill-formed.
-
-<!-- LOUIS: stopped here -->
 
 ## Free function example
 
@@ -258,12 +263,14 @@ void f() {
   new SubClass1();       // calls (3) with T=SubClass1
   new SubClass2();       // calls (4)
   new SubClass3();       // resolves (5) reports error due to deleted operator
-  new SubClass4();       // calls (6) as the class scoped allocator wins
+  new SubClass4();       // calls (6) as the class scoped operator wins
   new int();             // calls (2) with T=int
 }
 ```
 
-## In class example
+> Note: The above is for illustrative purposes only: it is a bad idea to provide a fully unconstrained type-aware `operator new`.
+
+## In-class example
 ```cpp
 // In class operator
 class SubClass1;
@@ -289,28 +296,22 @@ void f() {
   new SubClass2();       // calls (1) with T=SubClass2
   new SubClass3();       // calls (3)
   new SubClass4();       // calls (4) with T=SubClass4
-  ::new BaseClass();     // ingnores in class operators and uses appropriate global operator
+  ::new BaseClass();     // ignores in-class operators and uses appropriate global operator
 }
 ```
 
+<!--
 # Wording
 
-<!-- TODO: finish -->
-To simplify the text, we will refer to an allocation operator in which the first parameter is a specialization of
-`std::type_identity` as being a "type aware [de]allocation operator". For the declaration of a type aware [de]allocation
-operator to be valid, we explicitly require that the parameter be a (potentially dependent) specialization of
-`std::type_identity`, but not a fully dependent type. In other words, the compiler must be able to tell that the
-first parameter is of the form `std::type_identity<T>` at the time of parsing the declaration, but before the declaration
-has been instantiated in the case of a template. This is analogous to the current behavior where we require specific
-concrete types in the parameter list even in dependent contexts.
+To effectively support this proposal, it is necessary to update the definition of a usual deallocation function
+([basic.stc.dynamic.deallocation](https://timsong-cpp.github.io/cppwp/n4950/basic.stc.dynamic.deallocation)) to
+include this new parameter, which requires the following:
 
-To effectively support this new tag, it is necessary to update the definition of a usual deallocation function
-([basic.stc.dynamic.deallocation]) to include this new parameter, which requires the following:
-
-* Allow the first parameter to be a specialization of type_identity, and update to position requirements of later
-parameters to include that.
-* Allow the function to have template parameters as long as the function is a type aware `operator delete` and the
-only dependent parameter is a `std::type_identity` specialization in the first parameter position.
+* Allow the first parameter to be a specialization of `std::type_identity`, and update to position requirements of later
+  parameters to include that.
+* Allow the function to have template parameters as long as the function is `operator delete` and the
+  only dependent parameter is a `std::type_identity` specialization in the first parameter position.
+-->
 
 # Design choices and notes
 
@@ -423,7 +424,7 @@ that is used in the same way in the other operator variants.
 
 ### Problems with implicit capture of subtypes
 
-A scenerio we have discussed is developers wishing to provide custom allocators for specific types,
+A scenario we have discussed is developers wishing to provide custom allocators for specific types,
 when using a typed pointer as the tag, this would be written as
 
 ```cpp
@@ -511,6 +512,8 @@ allocator libraries all the way to general system allocators.
 
 ## Design choice: Destroying delete object type
 
+<!-- TODO: Oliver rewrite this -->
+
 One choice we have made is to not special case the treatment of destroying delete operators, so despite
 providing the concrete type of an allocator, we still require destroying delete to receive the root type
 as the object pointer, e.g.
@@ -585,10 +588,3 @@ meaningfully improve the developer experience, and it introduces a hazard wherei
 aware that simply namespacing the declarations is insufficient - it will frequently appear to work
 as expected - whereas there is already a strong understanding of the work involved in exposing and
 overriding global allocation functions.
-
-# Suggested polls
-
-1. Do we agree on the use of `std::type_identity` as the tag type
-2. Do we prefer `std::type_identity` before the size and alignment (status quo), or later in the argument list?
-3. Do we agree that type aware allocators should be accepted as usual deallocation functions
-

--- a/p2719.md
+++ b/p2719.md
@@ -20,15 +20,15 @@ expression like `new T(...)` will use that allocation function. Otherwise, the g
 replaced by users in a type-agnostic way, by implementing `void* operator new(size_t)` and its variants. A similar
 mechanism exists for _delete-expressions_.
 
-This paper proposes an extension to _new-expressions_ and _delete-expressions_ to provide the concrete type of an
-allocation or deallocation to the allocation functions. This is achieved via the addition of an additional tag argument
-of type `std::type_identity<TypeBeingAllocated>` that allows the provision of the concrete type to `operator new` and
-`operator delete`. This allows the addition of type specific implementations of `operator new` and `operator delete` for
-types that cannot have invasive class scoped allocators specified, and allows accurate type information to be provided
-when allocating subtypes.
+This paper proposes an extension to _new-expressions_ and _delete-expressions_ to provide the concrete type being
+[de]allocated to the allocation functions. This is achieved via the addition of an additional `std::type_identity<T>`
+tag argument that allows the provision of the concrete type to `operator new` and `operator delete`. This allows the
+creation of type-specific `operator new` and `operator delete` for types that cannot have intrusive class-scoped
+operators specified, and allows accurate type information to be provided when allocating subtypes.
 
-To add further convenience to these models, we also propose allowing these type aware interfaces to be namespace scoped,
-and add an additional ADL lookup for new and delete operator based on the type being allocated.
+To add further convenience to this model, we propose allowing these type-aware interfaces to be namespace-scoped,
+and add an additional ADL lookup for new and delete operator based on the type being allocated. The following describes
+(roughly) the search process performed by the compiler before and after this paper:
 
 ::: cmptable
 
@@ -147,6 +147,7 @@ T::operator delete[](void-ptr) // (1)
   - Simplified the lookup mechanism to avoid entangling overload resolution with name lookup
   - Allowed `std::type_identity` parameter in `operator new` defined at class scope
   - Modified mechanism to not take into account placement args for ADL (TODO: Explain why in Design section)
+  - Made the `std::type_identity<T>` argument first
   - TODO: Added justification for taking `std::type_identity<T>` instead of `T*` as a first argument
   - TODO: Added explanation of what happens w.r.t. ODR and mismatched new/delete operators
 

--- a/p2719.md
+++ b/p2719.md
@@ -429,6 +429,47 @@ being able to use usual deallocation functions. This is any environment where it
 may throw exceptions, and depend on object clean up, a condition that applies across from many custom "drop in"
 allocator libraries all the way to general system allocators.
 
+## Design choice: Destroying delete object type
+
+One choice we have made is to not special case the treatment of destroying delete operators, so despite
+providing the concrete type of an allocator, we still require destroying delete to receive the root type
+as the object pointer, e.g.
+
+```cpp
+struct Foo {
+  template <class T> void *operator new(type_identity<T>, size_t);
+  template <class T> void operator delete(type_identity<T>, Foo *, std::destroying_delete_t);
+};
+```
+
+We chose not to change the behavior here in order to simplify the semantic impact of this proposal, and
+keep it as close as possible to being just a new implicit parameter for new and delete operators. In
+principle in this model we could extend the proposal to allow
+
+```cpp
+struct Foo {
+  template <class T> void *operator new(type_identity<T>, size_t);
+  template <class T> void operator delete(type_identity<T>, T *, std::destroying_delete_t);
+};
+```
+
+However we note that the current specification does not allow
+
+```cpp
+struct Bar;
+struct Foo {
+  template <class T> void *operator new(type_identity<T>, size_t);
+  template <class T> void operator delete(type_identity<T>, T *, std::destroying_delete_t);
+};
+struct Bar : Foo { ... };
+```
+
+So in addition to the new implicit tag parameter and template argument, this would be introducing
+functionality that is not permitted in the existing language while in priciple being a semantically
+valid option. The authors of this proposal are not aware of the content of discussions when designing
+destroying delete so we do not know if this restriction was the product of techical arguments or
+the limitations of the language at the time, and so extending the behavior and semantics of destroying
+delete seemed out of scope for this proposal.
 
 # Suggested polls
 

--- a/p2719.md
+++ b/p2719.md
@@ -199,18 +199,18 @@ parameter types.
 struct SingleClass { };
 struct UnrelatedClass { };
 struct BaseClass { };
-struct SubClass1 : BaseClass1 { };
-struct SubClass2 : BaseClass1 { };
-struct SubClass3 : BaseClass1 { };
+struct SubClass1 : BaseClass { };
+struct SubClass2 : BaseClass { };
+struct SubClass3 : BaseClass { };
 void* operator new(std::type_identity<SingleClass>, std::size_t); // (1)
 template <typename T> void* operator new(std::type_identity<T>, std::size_t); // (2)
 
-template <typename T, typename = std::enable_if_t<std::is_base_of<BaseClass1, T>>>
+template <std::derived_from<BaseClass> T>
 void* operator new(std::type_identity<T>, std::size_t); // (3)
 void* operator new(std::type_identity<SubClass2>, std::size_t); // (4)
 void* operator new(std::type_identity<SubClass3>, std::size_t) = delete; // (5)
 
-struct SubClass4 : BaseClass1 {
+struct SubClass4 : BaseClass {
   void *operator new(size_t); // (6)
 };
 

--- a/p2719.md
+++ b/p2719.md
@@ -510,60 +510,50 @@ being able to use usual deallocation functions. This is any environment where it
 may throw exceptions, and depend on object clean up, a condition that applies across from many custom "drop in"
 allocator libraries all the way to general system allocators.
 
-## Design choice: Destroying delete object type
+## Design choice: Non-support for type-aware destroying delete
 
-<!-- TODO: Oliver rewrite this -->
-
-One choice we have made is to not special case the treatment of destroying delete operators, so despite
-providing the concrete type of an allocator, we still require destroying delete to receive the root type
-as the object pointer, e.g.
-
-```cpp
-struct Foo {
-  template <class T> void *operator new(type_identity<T>, size_t);
-  template <class T> void operator delete(type_identity<T>, Foo *, std::destroying_delete_t);
-};
-```
-
-We chose not to change the behavior here in order to simplify the semantic impact of this proposal, and
-keep it as close as possible to being just a new implicit parameter for new and delete operators. In
-principle we this proposal could be extended to allow:
+We have decided not to support type aware destroying delete as we believe it creates a user hazard. At a
+technical level there is no additional complexity in supporting type aware destroying delete, but the
+resulting semantics seem likely to cause a high risk of user confusion, for example given this hypothetical
+declaration
 
 ```cpp
 struct Foo {
-  template <class T> void *operator new(type_identity<T>, size_t);
-  template <class T> void operator delete(type_identity<T>, T *, std::destroying_delete_t);
+  ...
+  template <class T> void operator delete(type_identity<T>, Foo*, std::destroying_delete_t);
 };
+
+struct Bar : Foo {
+
+};
+
+void f(Foo* f) {
+  delete f; // calls Foo::operator delete<Foo>
+}
+void g(Bar *b) {
+  delete b; // calls Foo::operator delete<Bar>
+}
 ```
 
-But we note that the current specification also does not allow constructs such as the following:
+To a user this appears to be doing what they expect, but if we introduce the following
 
 ```cpp
-struct Bar;
-struct Foo {
-  void *operator new(size_t);
-  void operator delete(Foo *, std::destroying_delete_t);
-  void operator delete(Bar *, std::destroying_delete_t);
+struct Oops : Bar {
+
 };
-struct Bar : Foo { ... };
+
+void h(Oops *o) {
+  g(o);
+}
 ```
 
-So in addition to the new implicit tag parameter and template argument, this would be introducing
-functionality that is not permitted in the existing language while in priciple being a semantically
-valid option. The authors of this proposal are not aware of the content of discussions when designing
-destroying delete so we do not know if this restriction was the product of semantic arguments or
-the limitations of the language at the time. An obvious reason for the existing restriction is that
-the existing language has no way to verify a subtype relationship between types at the point the
-delete operator is declared, and fundamentally that restriction does not change with this proposal.
-A concretely typed destroying delete would have the same problem, and it is only by the delayed
-instantiation enabled by use of templates that the subtyping restriction could be enforced in our
-proposal.
-
-As a result, while the type of the pointer provided to a type aware destroying delete could be
-the concrete type at the point of invocation, the semantics of doing so don't meaningfully change
-from those present in the existing destroying delete specification. As a result we believe that
-extending destroying delete to support subtype dispatch is a more general issue that is outside of
-the scope of this proposal.
+By design, destroying delete does not perform any polymorphic dispatch, and as a result
+the type being passed to the operator may not be the true concrete type of the object
+being destroyed, but rather it would just be the type of the pointer being operated over.
+As a result in many basic tests it will appear to be "correct" from the user's point of
+view, but there is no guarantee that that will always be the case. Furthermore, even in
+the case where a user were to exhuastively test their code base at one time, the addition
+of any new subtypes in future would silently introduce the potential for a mismatch.
 
 ## Design choice: ADL
 

--- a/p2719.md
+++ b/p2719.md
@@ -38,11 +38,11 @@ interesting:
 
 ```cpp
 template <class T>
-  requires usable_with_custom_allocator<T>
+  requires use_special_allocation_scheme<T>
 void* operator new(std::type_identity<T>, std::size_t n) { ... }
 
 template <class T>
-  requires usable_with_custom_allocator<T>
+  requires use_special_allocation_scheme<T>
 void operator delete(std::type_identity<T>, void* ptr) { ... }
 ```
 
@@ -131,7 +131,7 @@ To avoid conficts with existing code, this parameter is placed as the first argu
 subject pointer. To avoid the complexities of ADL, this proposal does not change any of the _name lookup_ rules associated
 to _new_ and _delete_ expressions: it only changes the overload resolution that happens once a name has been found.
 
-For the declaration of a type aware [de]allocation operator to be valid, we explicitly require that the parameter be a
+For the declaration of a type-aware [de]allocation operator to be valid, we explicitly require that the parameter be a
 (potentially dependent) specialization of `std::type_identity`, but not a fully dependent type. In other words, the
 compiler must be able to tell that the first parameter is of the form `std::type_identity<T>` at the time of parsing
 the declaration, but before the declaration has been instantiated in the case of a template. This is analogous to the
@@ -140,7 +140,7 @@ current behavior where we require specific concrete types in the parameter list 
 Once a set of candidate declarations has been found we perform the same prioritized overload resolution steps,
 only with the addition of `std::type_identity<T>`, with a higher priority than the existing size and alignment
 parameters. For illustration, here is how overload resolution changes (`NEW` is the set of candidates found by
-name lookup for `operator new`, and `DELETE` is the equivalent for `operator delete`):
+name lookup for `operator new`, and `DELETE` is the equivalent for `operator delete`).
 
 If the user writes `new T(...)`, the compiler checks (in order):
 
@@ -149,14 +149,14 @@ If the user writes `new T(...)`, the compiler checks (in order):
 ### Before
 
 ```cpp
-// assuming T not overaligned
+// T not overaligned
 NEW(size_t)
 ```
 
 ### After
 
 ```cpp
-// assuming T not overaligned
+// T not overaligned
 NEW(type_identity<T>, size_t)
 NEW(size_t)
 ```
@@ -164,13 +164,13 @@ NEW(size_t)
 ---
 
 ```cpp
-// assuming T overaligned
+// T overaligned
 NEW(size_t, align_val_t)
 NEW(size_t)
 ```
 
 ```cpp
-// assuming T overaligned
+// T overaligned
 NEW(type_identity<T>, size_t, align_val_t)
 NEW(type_identity<T>, size_t)
 NEW(size_t, align_val_t)
@@ -186,8 +186,8 @@ If the user writes `delete ptr`, the compiler checks (in order):
 ### Before
 
 ```cpp
-// assuming T not overaligned
-DELETE(DefiningClass*, destroying_delete_t, ...)
+// T not overaligned
+DELETE(T-or-Base*, destroying_delete_t, ...)
 DELETE(void*, size_t)
 DELETE(void*)
 ```
@@ -195,8 +195,8 @@ DELETE(void*)
 ### After
 
 ```cpp
-// assuming T not overaligned
-DELETE(DefiningClass*, destroying_delete_t, ...)
+// T not overaligned
+DELETE(T-or-Base*, destroying_delete_t, ...)
 DELETE(type_identity<T>, void*, size_t)
 DELETE(type_identity<T>, void*)
 DELETE(void*, size_t)
@@ -206,16 +206,16 @@ DELETE(void*)
 ---
 
 ```cpp
-// assuming T overaligned
-DELETE(DefiningClass*, destroying_delete_t, ...)
+// T overaligned
+DELETE(T-or-Base*, destroying_delete_t, ...)
 DELETE(void*, size_t, align_val_t)
 DELETE(void*, align_val_t)
 DELETE(void*)
 ```
 
 ```cpp
-// assuming T overaligned
-DELETE(DefiningClass*, destroying_delete_t, ...)
+// T overaligned
+DELETE(T-or-Base*, destroying_delete_t, ...)
 DELETE(type_identity<T>, void*, size_t, align_val_t)
 DELETE(type_identity<T>, void*, align_val_t)
 DELETE(type_identity<T>, void*)
@@ -274,7 +274,7 @@ void f() {
 
 ## In-class example
 ```cpp
-// In class operator
+// In-class operator
 class SubClass1;
 struct BaseClass {
   template <typename T>
@@ -474,13 +474,13 @@ TODO(Louis): I don't understand this paragraph
 
 An alternative to this would be to require passing an implicit `type_identity` parameter to require the relevant
 parameter in the original function declaration always be a `type_identity<T>` specialization, similar to our
-definition of type aware allocators in general. This would differ from the behavior with respect to other implicit
+definition of type-aware allocators in general. This would differ from the behavior with respect to other implicit
 parameters that are permitted to bind to arbitrary template parameters.
 -->
 
 ## Design choice: Templated type-aware `operator delete` is a _usual deallocation function_
 
-Allowing type aware `operator delete` does require changes to the definition of usual deallocation functions,
+Allowing type-aware `operator delete` does require changes to the definition of usual deallocation functions,
 but the changes are conceptually simple and the cost of not supporting this case is extremely high.
 
 In the current specification, we place very tight requirements on what an `operator delete` declaration can look
@@ -577,13 +577,38 @@ For example, a special ADL lookup could be done based solely on the dynamic type
 Since this adds complexity to the proposal and implementation and doesn't provide great value, we are not
 pursuing it as part of this proposal.
 
-## Interactions with `std::allocator`
+## Interactions with `std::allocator<T>`
 
-TODO(Louis)
+Today, `std::allocator<T>::allocate` is specified to call `::operator new(std::size_t)` explicitly. Even
+if `T::operator new` exists, `std::allocator<T>` will not attempt to call it. We view this as a defect in
+the current Standard since `std::allocator<T>` could instead select the same operator that would be called
+in an expression like `new T(...)` (without the constructor call, obviously).
 
-## Interactions with ODR and mismatched `operator new` / `operator delete`
+This doesn't have an interaction with our proposal, except for making `std::allocator<T>`'s behavior a bit
+more unfortunate than it already is today. Indeed, users may rightly expect that `std::allocator<T>` will
+call their type-aware `operator new` when in reality that won't be the case.
 
-TODO(Louis)
+Since this deception already exists for `T::operator new`, we do not attempt to change `std::allocator<T>`'s
+behavior in this proposal. However, the authors are willing to investigate fixing this issue as a separate
+proposal, which will certainly present its own set of challenges (e.g. constant evaluation).
+
+## ODR implications and mismatched `operator new` / `operator delete`
+
+A concern that was raised in St-Louis was that this proposal would increase the likelihood of ODR violation
+caused by different declarations of `operator new`/`operator delete` being used in different TUs. For example,
+one TU would get `lib1::operator new` and another TU would use `lib2::operator delete` due to e.g. a different
+set of headers being included. Note that the exact same issue also applies to every other operator that is
+commonly used via ADL (like `operator+`), except that many such ODR violations may end up being more benign
+than a mismatched `new`/`delete`.
+
+First, we believe that the only way to avoid this issue (in general) is to properly constrain templated
+declarations, and nothing can prevent users from doing that incorrectly. However, since this proposal has
+dropped the ADL lookup, declarations of type-aware operators must now be in-class or global. This greatly
+simplifies the selection of an operator, which should make it harder for users to unexpectedly define an
+insufficiently constrained operator without immediately getting a compilation error.
+
+Furthermore, without ADL lookup, the ODR implications of this proposal are exactly the same as the existing
+ODR implications of user-defined placement new operators, which can be templates.
 
 ## Impact on the library
 

--- a/p2719.md
+++ b/p2719.md
@@ -255,10 +255,13 @@ it as a template argument instead. Unfortunately, this has a number of problems,
 is that without a tag parameter it is not possible to distinguish a type aware allocation operator from existing
 template operator declarations.
 
-This distinction is a requirement in order to permit type aware deallocation functions to be allowed as usual
-deallocation functions.
+The first problem of note is we want to support type aware deallocation functions as usual deallocation functions.
+Without an explicit type tag this distinction is not possible which leaves us unable to distinguish a type aware deallocation function from any other templated `operator delete`. Absent this distinction this feature would
+create the risk of inappropriately calling `operator delete` implementations in existing code bases in scnerios
+they have not previously been invoked.
 
-There are also questions of how these semantics interact with existing templated operators, as an example
+In addition to this issue, there are also questions of how these semantics interact with existing templated
+operators, as an example
 
 ```cpp
 template <class ...Args>
@@ -369,20 +372,7 @@ out of line, and so the difference may matter.
 
 ## Design choice: Order of arguments
 
-** [oliver] NOTE: i think we should switch to type_identity first as it ensures existing code cannot conflict**
-
 When writing this paper, we went back and forth of the order of arguments. This paper proposes:
-
-```c++
-operator new(std::size_t, std::type_identity<T>, placement-args...)
-operator new(std::size_t, std::align_val_t, std::type_identity<T>, placement-args...)
-
-operator delete(void*, std::type_identity<T>)
-operator delete(void*, std::size_t, std::type_identity<T>)
-operator delete(void*, std::size_t, std::align_val_t, std::type_identity<T>)
-```
-
-Another approach would be:
 
 ```c++
 operator new(std::type_identity<T>, std::size_t, placement-args...)
@@ -393,21 +383,51 @@ operator delete(std::type_identity<T>, void*, std::size_t)
 operator delete(std::type_identity<T>, void*, std::size_t, std::align_val_t)
 ```
 
-We would like input from EWG on this matter.
+Another approach would be:
 
+```c++
+operator new(std::size_t, std::type_identity<T>, placement-args...)
+operator new(std::size_t, std::align_val_t, std::type_identity<T>, placement-args...)
 
+operator delete(void*, std::type_identity<T>)
+operator delete(void*, std::size_t, std::type_identity<T>)
+operator delete(void*, std::size_t, std::align_val_t, std::type_identity<T>)
+```
 
+The existing specification allows for the existence of template (including variadic template) declarations of
+operator new and delete, and this functionality is used in existing code bases. This leads to problems compiling
+real world code where overload resolution will allow selection of a non-SFINAE-safe declaration, and subsequently
+breaks during compilation.
 
+Placing the type tag preceding the size or pointer argument ensures that no existing operator definition can
+match this new tag, and so we are guaranteed to be free from conflict.
 
-We believe that this is not a far fetched possibility and that we may break some code if we went down that route.
-Even worse, an existing templated `operator new` could match even though it was never intended to be called. The
-result would be that the first template argument is explicitly provided by the compiler, which could result in a
-substitution failure (that is acceptable) or in a valid function call triggering an implicit conversion to the
-now-explicitly-provided first template argument, which would change the meaning of valid programs.
+An alternative to this would be to require passing an implicit `type_identity` parameter to require the relevant
+parameter in the original function declaration always be a `type_identity<T>` specialization, similar to our
+definition of type aware allocators in general. This would differ from the behavior with respect to other implicit
+parameters that are permitted to bind to arbitrary template parameters.
 
-Finally, without this tag parameter it is not possible to distinguish a template type aware allocator from any other
-templated operator. This distinction is necessary for the semantics of new and delete in a number of contexts, especially
-the concept of a "usual deallocation function".
+## Design choice: Allowing template type aware `operator delete` as a usual deallocation function
+
+Allowing type aware `operator delete` does require changes to the definition of usual deallocation functions,
+but the changes are conceptually simple and the cost of not supporting this case is extremely high.
+
+In the current specification we already place very tight requirements on what the type of an `operator delete`
+definition must be in order to be considered a "usual deallocation function". The reason these definitions have
+not allow template functions previously is because all of the implicit parameters are monomorphic types. In that
+environment such a restriction makes sense.
+
+However in this proposal we have introduced an implicit parameter that for which it is correct, and 
+expected, for the method to be templated. To that end we allowed a template `operator delete` to be
+considered a usual deallocation function, as long as the only dependently typed parameter is the implicit
+`type_identity` parameter. To our minds, these semantics match the "intent" of the restrictions already in
+place for the other implicit parameters.
+
+The cost of not allowing template type aware `operator delete` as a usual deallocation function is very high,
+as it functionally prohibits the use of type aware allocation operators in any environment that depends of
+being able to use usual deallocation functions. This is any environment where it is expected that constructors
+may throw exceptions, and depend on object clean up, a condition that applies across from many custom "drop in"
+allocator libraries all the way to general system allocators.
 
 <!--
 ## Should a templated operator delete be allowed as a usual allocation function?

--- a/p2719.md
+++ b/p2719.md
@@ -8,8 +8,8 @@ author:
     email: <ldionne@apple.com>
   - name: Oliver Hunt
     email: <oliver@apple.com>
-toc: false
-toc-depth: 4
+toc: true
+toc-depth: 2
 ---
 
 # Introduction
@@ -49,13 +49,11 @@ void operator delete(std::type_identity<T>, void* ptr) { ... }
 # Revision history
 
 - R0: Initial version
-- R1 (based on St-Louis feedback and implementation experience):
-  - Simplified the lookup mechanism by removing the need to perform ADL
+- R1:
+  - Simplified the lookup mechanism by removing the need to perform ADL (based on implementation experience)
   - Allowed `std::type_identity` parameter for in-class `T::operator new` for consistency
-  - Added justification for taking `std::type_identity<T>` instead of `T*` as a first argument.
-  - LOUIS: TODO: Added explanation of what happens w.r.t. ODR and mismatched new/delete operators
-  - LOUIS: TODO: Mention interactions with `std::allocator` and that we can resolve that separately
-  - Added justification for not allowing type-aware destroying delete
+  - Made `std::type_identity` as the first parameter
+  - Documented design choices and changes based on feedback and implementation experience
 
 # Motivation
 
@@ -319,109 +317,112 @@ include this new parameter, which requires the following:
 
 # Design choices and notes
 
-## Impact on the library
+## Design choice: `std::type_identity<T>` vs "raw" template argument
 
-This proposal does not have any impact on the library, since this only tweaks the search process performed by the
-compiler when it evaluates a new-expression and a delete-expression. In particular, we do not propose adding new
-type-aware free function `operator new` variants in the standard library at this time, althought this could be
-investigated in the future.
-
-## Design choice: Template argument vs tag parameter
-
-In an earlier draft, this paper was proposing the following (seemingly simpler) mechanism instead. Instead of
-reusing `std::type_identity` as a tag parameter, the compiler would search as per the following expression:
+In an earlier draft, this paper was proposing the following (seemingly simpler) mechanism. Instead of using
+`std::type_identity<T>` as a tag, the compiler would search as per the following expression:
 
 ```cpp
 operator new<T>(sizeof(T), args...)
 ```
 
-The only difference here is that we're not passing `std::type_identity` as a first argument and we are passing
-it as a template argument instead. Unfortunately, this has a number of problems, the most significant of which
-is that without a tag parameter it is not possible to distinguish a type aware allocation operator from existing
-template operator declarations.
+The only difference here is that we're passing the type being allocated directly as a template argument instead of
+using a `std::type_identity<T>` tag parameter. Unfortunately, this has a number of problems, the most significant
+being that it's not possible to distinguish the newly-introduced type-aware operator from existing template
+`operator new` and `operator delete` declarations.
 
-The first problem of note is we want to support type aware deallocation functions as usual deallocation functions.
-Without an explicit type tag this distinction is not possible which leaves us unable to distinguish a type aware deallocation function from any other templated `operator delete`. Absent this distinction this feature would
-create the risk of inappropriately calling `operator delete` implementations in existing code bases in scnerios
-they have not previously been invoked.
-
-In addition to this issue, there are also questions of how these semantics interact with existing templated
-operators, as an example
+For example, a valid `operator new` declaration today would be:
 
 ```cpp
 template <class ...Args>
-void operator delete(void *, Args...);
-size_t *sz_ptr = ...;
-delete sz_ptr;
+void* operator new(std::size_t, Args...);
 ```
 
-Because in this model allocation of a type aware operator must be explicit, we will explicitly instantiate
-this as `operator delete<size_t>` as a type aware allocator, and in doing so this would also be validly
-interpreted as a size aware deallocator. It is unclear which would be preferred - if either - but for existing
-code this is the difference between the candidate being a valid usual deallocation function or not, so this
-semantic change (althought theoretically not encounterable in this specific example) could introduce calls to
-deletion operators where previously none occurred.
+Hence, an expression like `new (42) int(3)` which would result in a call like `operator new<int>(sizeof(int), 42)`
+could result in this operator being called with a meaning that isn't clear -- is it a type-aware (placement) operator
+or a type-unaware placement operator? This also means that existing and legal operators could start being called in
+code bases that don't expect it, which is problematic.
 
-Finally, using a tag parameter allows a developer to more easliy specify allocation apis that are constrained
-to specific concrete types. There are cases where a developer may not be able to specify in class allocation
-operators, and being able to specify free operators with explict type constraints resolves this problem, e.g.
+Beyond that being confusing for users, this also creates a legitimate problem for the compiler since the resolution
+of new and delete expressions is based on checking various forms of the operators using different priorities. In order
+for this to make sense, the compiler has to be able to know exactly what "category" of operator a declaration falls in,
+so it can perform overload resolution at each priority on the right candidates.
 
-Without a tag parameter a developer in this position is required to write code similar to:
-
-```cpp
-struct S { ... };
-template <typename T, typename = std::enable_if_t<std::is_same_v<T, S>>>
-void *operator new(size_t);
-```
-
-Whereas with a tag they can simply specify the restriction explicity
-
-```cpp
-struct S { ... };
-void *operator new(std::type_identity<S>, size_t);
-```
-
-While this last example is a minor nicety for developers, it is something we have considered.
+Finally, when a constructor in a _new-expression_ throws an exception, an `operator delete` that must be a _usual
+deallocation function_ gets called to clean up. If there is no matching usual deallocation function, no cleanup is
+performed. Using a template parameter instead of a tag argument could lead to code where no cleanup happened to now
+find a valid usual deallocation function and perform a cleanup.
 
 Taken together we believe these issues warrant the use of an explicit tag parameter.
 
-## Design choice: Use of `std::type_identity<T>` vs `T*`
+## Design choice: `std::type_identity<T>` vs `T*`
 
-In this proposal we have used `std::type_identity<T>` rather than using the outwardly simpler option of `T*`.
+This proposal uses `std::type_identity<T>` as a tag argument rather than passing a first argument of type `T*`. At
+first sight, passing `T*` as a first tag argument seems to simplify the proposal and decouple the compiler from the
+standard library.
 
-This perceived simplicity hides an array of subtle problems that are avoided through the use of `std::type_identity`.
+However, this approach hides an array of subtle problems that are avoided through the use of `std::type_identity`.
 
 ### Problems with the value being passed
-The first problem is the value that is passed as the tag parameter. Given an allocator signature of the form
+
+The first problem is the value being passed as the tag parameter. Given operator signatures of the form
 
 ```cpp
-template <class T> void *operator new(T*, size_t) { ... }
-template <class T> void operator delete(T*, void *) { ... }
+template <class T> void *operator new(T*, size_t);
+template <class T> void operator delete(T*, void*);
 ```
 
-A developer could reasonably be assumed to understand that the tag parameter to `operator new` would necessarily
-be a null pointer, but for operator delete we can be assured that people will be confused about receiving two
-pointer parameters, where the explicitly typed parameter is null. However we cannot pass the object pointer through
-this parameter as this operator is called after the object has been destroyed, so providing the original pointer
-would be an invitation to guaranteed undefined behaviour.
-
-### Problems with implicit capture of subtypes
-
-A scenario we have discussed is developers wishing to provide custom allocators for specific types,
-when using a typed pointer as the tag, this would be written as
+Under the hood, the compiler could perform calls like
 
 ```cpp
-struct S;
-void *operator new(S*, size_t) { ... }
+// T* ptr = new T(...)
+operator new<T>((T*)nullptr, sizeof(T));
+
+// delete ptr
+operator delete<T>((T*)nullptr, ptr);
 ```
 
-However this operator will also match any subtypes of `S`, which may be intended, but if it is not
-intended the conversion from `Subtype*` to `S*` is entirely silent and may not be noticed. The robust
-solution for this requires a reversion to the tag-free design above, i.e
+A developer could reasonably be assumed to know that the tag parameter to `operator new` can't be anything but a
+null pointer. However, for `operator delete` we can be assured that people will be confused about receiving two
+pointer parameters, where the explicitly typed parameter is `nullptr`. Also note that we cannot pass the object
+pointer through that parameter as `operator delete` is called after the object has been destroyed. Passing the
+memory to be deallocated through a typed pointer is an incitation to use that memory as a `T` object, which would
+be undefined behavior.
+
+### Silent conversions to base types
+
+A scenario we have discussed is developers wishing to provide custom [de]allocation operators for a whole
+class hierarchy. When using a typed pointer as the tag, this would be written as:
 
 ```cpp
-template <typename T, typename = std::enable_if_t<std::is_same_v<T, S>>>
-void *operator new(T*, size_t);
+struct Base { };
+void* operator new(Base*, std::size_t);
+void operator delete(Base*, void*);
+```
+
+This operator would then also match any derived types of `Base`, which may or may not be intended. If not intended,
+the conversion from `Derived*` to `Base*` would be entirely silent and may not be noticed. Furthermore, this would
+basically defeat the purpose of providing type knowledge to the allocator, since only the type of the base class
+would be known. We believe that the correct way of implementing an operator for a hierarchy is this:
+
+```cpp
+struct Base {
+  template <class T>
+  void* operator new(std::type_identity<T>, std::size_t); // T is the actual type being allocated
+
+  template <class T>
+  void operator delete(std::type_identity<T>, void*);
+};
+```
+
+Or alternatively, in the global namespace:
+
+```cpp
+template <std::derived_from<Base> T>
+void* operator new(std::type_identity<T>, std::size_t);
+
+template <std::derived_from<Base> T>
+void operator delete(std::type_identity<T>, void*);
 ```
 
 ### Performance considerations
@@ -434,9 +435,11 @@ In principle this difference should be minor for templated operators as they are
 so the calling convention is not relevant, but for non-template definitions the implementation can be
 out of line, and so the difference may matter.
 
-## Design choice: Order of arguments
+For all of these reasons, we believe that a tag type like `std::type_identity` is the right design choice.
 
-When writing this paper, we went back and forth of the order of arguments. This paper proposes:
+## Design choice: Location of `std::type_identity<T>`
+
+When writing this paper, we went back and forth of the order of arguments. This version of the paper proposes:
 
 ```c++
 operator new(std::type_identity<T>, std::size_t, placement-args...)
@@ -460,104 +463,131 @@ operator delete(void*, std::size_t, std::align_val_t, std::type_identity<T>)
 
 The existing specification allows for the existence of template (including variadic template) declarations of
 operator new and delete, and this functionality is used in existing code bases. This leads to problems compiling
-real world code where overload resolution will allow selection of a non-SFINAE-safe declaration, and subsequently
-breaks during compilation.
+real world code where overload resolution will allow selection of a non-SFINAE-safe declaration and subsequently
+break during compilation.
 
-Placing the type tag preceding the size or pointer argument ensures that no existing operator definition can
-match this new tag, and so we are guaranteed to be free from conflict.
+Placing the tag argument first ensures that no existing operator definition can match, and so we are guaranteed
+to be free from conflicts.
+
+<!--
+TODO(Louis): I don't understand this paragraph
 
 An alternative to this would be to require passing an implicit `type_identity` parameter to require the relevant
 parameter in the original function declaration always be a `type_identity<T>` specialization, similar to our
 definition of type aware allocators in general. This would differ from the behavior with respect to other implicit
 parameters that are permitted to bind to arbitrary template parameters.
+-->
 
-## Design choice: Allowing template type aware `operator delete` as a usual deallocation function
+## Design choice: Templated type-aware `operator delete` is a _usual deallocation function_
 
 Allowing type aware `operator delete` does require changes to the definition of usual deallocation functions,
 but the changes are conceptually simple and the cost of not supporting this case is extremely high.
 
-In the current specification we already place very tight requirements on what the type of an `operator delete`
-definition must be in order to be considered a "usual deallocation function". The reason these definitions have
-not allow template functions previously is because all of the implicit parameters are monomorphic types. In that
-environment such a restriction makes sense.
+In the current specification, we place very tight requirements on what an `operator delete` declaration can look
+like in order to be considered a _usual deallocation function_. The reason this definition previously disallowed
+function templates is that all of the implicit parameters are monomorphic types. That restriction made sense previously.
 
-However in this proposal we have introduced an implicit parameter that for which it is correct, and
-expected, for the method to be templated. To that end we allowed a template `operator delete` to be
-considered a usual deallocation function, as long as the only dependently typed parameter is the implicit
-`type_identity` parameter. To our minds, these semantics match the "intent" of the restrictions already in
-place for the other implicit parameters.
+However, this proposal introduces a new form of the operators for which it is correct (even expected) to be a
+function template. To that end, we allow a templated `operator delete` to be considered a usual deallocation
+function, as long as the only dependently-typed parameter is the first `std::type_identity<T>` parameter.
+To our minds, these semantics match the "intent" of the restrictions already in place for the other implicit
+parameters like `std::align_val_t`.
 
-The cost of not allowing template type aware `operator delete` as a usual deallocation function is very high,
-as it functionally prohibits the use of type aware allocation operators in any environment that depends of
-being able to use usual deallocation functions. This is any environment where it is expected that constructors
-may throw exceptions, and depend on object clean up, a condition that applies across from many custom "drop in"
-allocator libraries all the way to general system allocators.
+The cost of not allowing a templated type-aware `operator delete` as a usual deallocation function is very high,
+as it functionally prohibits the use of type-aware allocation operators in any environment that requires the ability
+to clean up after a constructor has thrown an exception.
 
-## Design choice: Non-support for type-aware destroying delete
+## Design choice: No support for type-aware destroying delete
 
-We have decided not to support type aware destroying delete as we believe it creates a user hazard. At a
-technical level there is no additional complexity in supporting type aware destroying delete, but the
-resulting semantics seem likely to cause a high risk of user confusion, for example given this hypothetical
-declaration
+We have decided not to support type-aware destroying delete as we believe it creates a user hazard. At a
+technical level there is no additional complexity in supporting type-aware destroying delete, but the
+resulting semantics seem likely to cause a lot of confusion. For example, given this hypothetical declaration:
 
 ```cpp
 struct Foo {
   ...
-  template <class T> void operator delete(type_identity<T>, Foo*, std::destroying_delete_t);
+  template <class T>
+  void operator delete(std::type_identity<T>, Foo*, std::destroying_delete_t);
 };
 
-struct Bar : Foo {
+struct Bar : Foo { };
 
-};
-
-void f(Foo* f) {
-  delete f; // calls Foo::operator delete<Foo>
+void f(Foo* foo) {
+  delete foo; // calls Foo::operator delete<Foo>
 }
-void g(Bar *b) {
-  delete b; // calls Foo::operator delete<Bar>
+
+void g(Bar *bar) {
+  delete bar; // calls Foo::operator delete<Bar>
 }
 ```
 
-To a user this appears to be doing what they expect, but if we introduce the following
+To a user this appears to be doing what they expect. However, consider the following:
 
 ```cpp
-struct Oops : Bar {
+struct Oops : Bar { };
 
-};
-
-void h(Oops *o) {
-  g(o);
+void h(Oops *oops) {
+  g(oops); // calls Foo::operator delete<Bar> from within g()
 }
 ```
 
-By design, destroying delete does not perform any polymorphic dispatch, and as a result
-the type being passed to the operator may not be the true concrete type of the object
-being destroyed, but rather it would just be the type of the pointer being operated over.
-As a result in many basic tests it will appear to be "correct" from the user's point of
-view, but there is no guarantee that that will always be the case. Furthermore, even in
-the case where a user were to exhuastively test their code base at one time, the addition
-of any new subtypes in future would silently introduce the potential for a mismatch.
+By design, destroying delete does not perform any polymorphic dispatch, and as a result the type being passed
+to the operator is not be the dynamic type of the object being destroyed, but rather its static type. As a
+result, basic functionality will appear to work correctly from the user's point of view when in reality the
+rules are much subtler than they seem.
 
-## Design choice: ADL
+Given that the design intent of destroying delete is for users to manage destruction and dispatching manually,
+we believe that adding type-awareness to destroying delete will add little value while creating the potential
+for confusion, so we decided not to do it.
 
-The initial proposal allowed the specification of type aware allocators in namespaces that could
-then be resolved via ADL. Upon further consideration this introduces a number of hazards to the
-language that are complex to resolve robustly and as a result we have dropped support for
-namespaced allocator declarations and removed the use of ADL from the proposal.
+## Design choice: Dropped support for ADL
 
-The first problem is declarations discovered from ADL over placement arguments. For operator new
-these are not a problem, however the delete operator does not support placement arguments, so the
-search scope can be significantly different between `new (args) Type` and the subsequent
-`delete Object`.
+The initial proposal allowed the specification of type-aware operators in namespaces that would then be
+resolved via ADL. Upon further consideration, this introduces a number of challenges that are difficult
+to resolve robustly. As a result, we have dropped support for namespace-scope operator declarations and
+removed the use of ADL from the proposal.
 
-Our hope was that by allowing namespaced operators we would simplify the work of constraining for
-a library to constrain a custom allocator to just the types in that library, however there exist
-myriad mechanisms by which a simple namespace only constraint is unintentionally expanded, the most
-trivial of which is `new Namespace1::Type<Namespace2::Type>`. As a result a conscientious developer
-will always need to appropriately constrain their type aware API, even if they were scoped.
+The first problem is that ADL would be based on the type of all arguments passed to `operator new`,
+including placement arguments. While this is not a problem for `operator new` itself, `operator delete`
+does not get the same placement arguments, which would potentially change the set of associated namespaces
+used to resolve `new` and `delete`.
 
-As that work is functionally always required, the addition of ADL to the search phase does not
-meaningfully improve the developer experience, and it introduces a hazard wherein a developer is not
-aware that simply namespacing the declarations is insufficient - it will frequently appear to work
-as expected - whereas there is already a strong understanding of the work involved in exposing and
-overriding global allocation functions.
+One of our original motivations for allowing namespace-scoped operators was to simplify the task of
+providing operators for a whole library. However, since ADL is so viral, the set of associated namespaces
+can easily grow unintentionally (e.g. `new lib1::Foo<lib2::Bar>(...)`), which means that developers would
+have to appropriately constrain their type-aware operators anyway. In other words, we believe that a
+declaration like this would never have been a good idea in the first place:
+
+```cpp
+namespace lib {
+  // intent: override for all types in this namespace
+  template <class T>
+  void* operator new(std::type_identity<T>, std::size_t);
+}
+```
+
+There are too many ways in which an unconstrained declaration like this can break, including an unexpected
+set of associated namespaces or even a mere `using namespace lib;`.
+
+Given the need to constrain a type-aware operator anyway, we believe that allowing namespace-scoped operators
+is merely a nice-to-have but not something that we need fundamentally. Furthermore, adding this capability to
+the language could always be pursued as a separate proposal since that concern can be tackled orthogonally.
+For example, a special ADL lookup could be done based solely on the dynamic type being [de]allocated.
+
+Since this adds complexity to the proposal and implementation and doesn't provide great value, we are not
+pursuing it as part of this proposal.
+
+## Interactions with `std::allocator`
+
+TODO(Louis)
+
+## Interactions with ODR and mismatched `operator new` / `operator delete`
+
+TODO(Louis)
+
+## Impact on the library
+
+This proposal does not have any impact on the library, since this only tweaks the search process performed by the
+compiler when it evaluates a new-expression and a delete-expression. In particular, we do not propose adding new
+type-aware free function `operator new` variants in the standard library at this time, althought this could be
+investigated in the future.

--- a/p2719.md
+++ b/p2719.md
@@ -241,6 +241,132 @@ compiler when it evaluates a new-expression and a delete-expression. In particul
 type-aware free function `operator new` variants in the standard library at this time, althought this could be
 investigated in the future.
 
+## Design choice: Template argument vs tag parameter
+
+In an earlier draft, this paper was proposing the following (seemingly simpler) mechanism instead. Instead of
+reusing `std::type_identity` as a tag parameter, the compiler would search as per the following expression:
+
+```cpp
+operator new<T>(sizeof(T), args...)
+```
+
+The only difference here is that we're not passing `std::type_identity` as a first argument and we are passing
+it as a template argument instead. Unfortunately, this has a number of problems, the most significant of which
+is that without a tag parameter it is not possible to distinguish a type aware allocation operator from existing
+template operator declarations.
+
+This distinction is a requirement in order to permit type aware deallocation functions to be allowed as usual
+deallocation functions.
+
+There are also questions of how these semantics interact with existing templated operators, as an example
+
+```cpp
+template <class ...Args>
+void operator delete(void *, Args...);
+size_t *sz_ptr = ...;
+delete sz_ptr;
+```
+
+Because in this model allocation of a type aware operator must be explicit, we will explicitly instantiate
+this as `operator delete<size_t>` as a type aware allocator, and in doing so this would also be validly
+interpreted as a size aware deallocator. It is unclear which would be preferred - if either - but for existing
+code this is the difference between the candidate being a valid usual deallocation function or not, so this
+semantic change (althought theoretically not encounterable in this specific example) could introduce calls to
+deletion operators where previously none occurred.
+
+Finally, using a tag parameter allows a developer to more easliy specify allocation apis that are constrained
+to specific concrete types. There are cases where a developer may not be able to specify in class allocation
+operators, and being able to specify free operators with explict type constraints resolves this problem, e.g.
+
+Without a tag parameter a developer in this position is required to write code similar to:
+
+```cpp
+struct S { ... };
+template <typename T, typename = std::enable_if_t<std::is_same_v<T, S>>>
+void *operator new(size_t);
+```
+
+Whereas with a tag they can simply specify the restriction explicity
+
+```cpp
+struct S { ... };
+void *operator new(std::type_identity<S>, size_t);
+```
+
+While this last example is a minor nicety for developers, it is something we have considered.
+
+Taken together we believe these issues warrant the use of an explicit tag parameter.
+
+## Design choice: Use of `std::type_identity<T>` vs `T*`
+
+In this proposal we have used `std::type_identity<T>` rather than using the outwardly simpler option of `T*`.
+
+This perceived simplicity hides an array of subtle problems that are avoided through the use of `std::type_identity`.
+
+### Problems with the value being passed
+The first problem is the value that is passed as the tag parameter. Given an allocator signature of the form 
+
+```cpp
+template <class T> void *operator new(T*, size_t) { ... }
+template <class T> void operator delete(T*, void *) { ... }
+```
+
+A developer could reasonably be assumed to understand that the tag parameter to `operator new` would necessarily
+be a null pointer, but for operator delete we can be assured that people will be confused about receiving two
+pointer parameters, where the explicitly typed parameter is null. However we cannot pass the object pointer through
+this parameter as this operator is called after the object has been destroyed, so providing the original pointer
+would be an invitation to guaranteed undefined behaviour.
+
+The confusion is further increased when considering a destroying operator delete
+
+```cpp
+struct Foo {
+  template <class T> void operator delete(T*, Foo *, std::destroying_delete_t) { ... }
+};
+
+struct Bar : Foo { ... };
+
+Bar *bar = ...;
+delete bar;
+// compiler invokes
+Foo::operator delete<Bar>(nullptr, &bar, std::destroying_delete);
+```
+
+In this case the the developer's deletion operator is invoked on an object that has not been
+destroyed, yet the concretely typed parameter is still a null pointer. Allowing the pointer
+to be the object being deleted would lead to the same pointer being passed as two parameters
+which may seem confusing, and introduces an arbitrary difference in the semantics of a parameter
+that is used in the same way in the other operator variants.
+
+### Problems with implicit capture of subtypes
+
+A scenerio we have discussed is developers wishing to provide custom allocators for specific types,
+when using a typed pointer as the tag, this would be written as
+
+```cpp
+struct S;
+void *operator new(S*, size_t) { ... }
+```
+
+However this operator will also match any subtypes of `S`, which may be intended, but if it is not
+intended the conversion from `Subtype*` to `S*` is entirely silent and may not be noticed. The robust
+solution for this requires a reversion to the tag-free design above, i.e
+
+```cpp
+template <typename T, typename = std::enable_if_t<std::is_same_v<T, S>>>
+void *operator new(T*, size_t);
+```
+
+### Performance considerations
+
+There is a fundamental difference between `T*` and `std::type_identity<T>` in that `T*` is a type that
+has an actual value and size, whereas `std::type_identity` is a zero sized record. This difference means
+that the `T*` model results in an additional parameter being required in the generated code, whereas
+the zero sized `type_identity` parameter does not exist in the majority of calling conventions.
+In principle this difference should be minor for templated operators as they are typically inlined and
+so the calling convention is not relevant, but for non-template definitions the implementation can be
+out of line, and so the difference may matter.
+
 ## Design choice: Order of arguments
 
 ** [oliver] NOTE: i think we should switch to type_identity first as it ensures existing code cannot conflict**
@@ -269,24 +395,9 @@ operator delete(std::type_identity<T>, void*, std::size_t, std::align_val_t)
 
 We would like input from EWG on this matter.
 
-## Design choice: Template argument vs `std::type_identity`
 
-In an earlier draft, this paper was proposing the following (seemingly simpler) mechanism instead. Instead of
-reusing `std::type_identity`, the compiler would search as per the following expression:
 
-```cpp
-operator new<T>(sizeof(T), args...)
-```
 
-The only difference here is that we're not passing `std::type_identity` as a first argument and we are passing
-it as a template argument instead. Unfortunately, this has a number of problems. First, this doesn't allow ADL to kick
-in, severely reducing the flexibility for defining the operator. Another problem is that existing code is allowed to
-have defined a global `operator new` like so:
-
-```cpp
-template <class ...Args>
-void* operator new(std::size_t size, Args ...args);
-```
 
 We believe that this is not a far fetched possibility and that we may break some code if we went down that route.
 Even worse, an existing templated `operator new` could match even though it was never intended to be called. The
@@ -297,35 +408,6 @@ now-explicitly-provided first template argument, which would change the meaning 
 Finally, without this tag parameter it is not possible to distinguish a template type aware allocator from any other
 templated operator. This distinction is necessary for the semantics of new and delete in a number of contexts, especially
 the concept of a "usual deallocation function".
-
-## Is the current name lookup for `T::operator new` done this way on purpose?
-
-Currently, the search that happens for a new-expression is worded such that if a `T::operator new` is found and
-overload resolution fails, the program is ill-formed. As explained in this proposal, this is stricter than needed
-and we propose relaxing that.
-
-However, one side effect of this strictness is that the compiler will error if a user defines some variants of
-`T::operator new` but forgets to define some other variants. [For example](https://godbolt.org/z/vEsc81h59):
-
-```cpp
-struct arg { };
-
-struct Foo {
-  static void* operator new(std::size_t, arg);
-};
-
-int main() {
-  new Foo();
-}
-```
-
-Today, this is a compiler error because we find `Foo::operator new` and then fail to perform overload resolution,
-so we don't fall back to the global `::operator new`. I don't know whether this is by design or just an unintended
-consequence of the wording, however this seems a bit contrived.
-
-In all cases, if we wanted this to remain ill-formed, we could either count on compiler diagnostics to warn in that
-case, or we could word the search process to say that if the overload resolution on `T::operator new` fails, the
-program is ill-formed and the search stops. This doesn't seem useful to me, but it's on the table.
 
 <!--
 ## Should a templated operator delete be allowed as a usual allocation function?

--- a/p2719.md
+++ b/p2719.md
@@ -21,7 +21,7 @@ replaced by users in a type-agnostic way, by implementing `void* operator new(si
 mechanism exists for _delete-expressions_.
 
 This paper proposes an extension to _new-expressions_ and _delete-expressions_ to provide the concrete type being
-[de]allocated to the allocation functions. This is achieved via the addition of an additional `std::type_identity<T>`
+[de]allocated to the allocation functions. This is achieved via the use of an additional `std::type_identity<T>`
 tag argument that allows the provision of the concrete type to `operator new` and `operator delete`. In addition to
 providing valuable information to the allocator, this allows the creation of type-specific `operator new` and
 `operator delete` for types that cannot have intrusive class-scoped operators specified.

--- a/p2719.md
+++ b/p2719.md
@@ -183,52 +183,76 @@ parameters. This gives us the following overload resolution ordering for operato
 4. NEW(size_t, args...)
 ```
 
+If multiple candidates match a given set of parameters, then operator prioritisation and selection is performed
+according to standard constraint precedence rules.
+
 When a constructor throws an exception, a cleanup call is made to `operator delete`. The semantics of this cleanup
 resolution remain essentially the same, the only difference being that the `operator delete` selected during overload
 resolution must have the same type awareness as the preceding `operator new` or the program is considered ill formed.
 
-Overload resolution for delete expressions is effectively the same, only with minor variations on parameter types
+Overload resolution for delete expressions is effectively the same, only with minor variations on the implicit
+parameter types.
+
+## Free function example
 
 ```cpp
-1. If destroying delete is applicable:
-  1. DELETE(type_identity<T>, <Destroying Type>*, destroying_delete_t, size_t, align_val_t)
-  2. DELETE(type_identity<T>, <Destroying Type>*, destroying_delete_t, size_t)
-  3. DELETE(type_identity<T>, <Destroying Type>*, destroying_delete_t)
-  4. DELETE(<Destroying Type>*, destroying_delete_t, size_t, align_val_t)
-  5. DELETE(<Destroying Type>*, destroying_delete_t, size_t)
-  6. DELETE(<Destroying Type>*, destroying_delete_t)
-2. DELETE(type_identity<T>, void*, size_t, align_val_t)
-3. DELETE(type_identity<T>, void*, size_t)
-4. DELETE(type_identity<T>, void*)
-5. DELETE(void*, size_t, align_val_t)
-6. DELETE(void*, size_t)
-7. DELETE(void*)
-```
+struct SingleClass { };
+struct UnrelatedClass { };
+struct BaseClass { };
+struct SubClass1 : BaseClass1 { };
+struct SubClass2 : BaseClass1 { };
+struct SubClass3 : BaseClass1 { };
+void* operator new(std::type_identity<SingleClass>, std::size_t); // (1)
+template <typename T> void* operator new(std::type_identity<T>, std::size_t); // (2)
 
-## Example
+template <typename T, typename = std::enable_if_t<std::is_base_of<BaseClass1, T>>>
+void* operator new(std::type_identity<T>, std::size_t); // (3)
+void* operator new(std::type_identity<SubClass2>, std::size_t); // (4)
+void* operator new(std::type_identity<SubClass3>, std::size_t) = delete; // (5)
 
-```cpp
-// OLIVER: TODO: Update these examples
-namespace lib {
-  struct Foo { };
-  void* operator new(std::size_t, std::type_identity<Foo>); // (1)
-
-  struct Foo2 { };
-}
-
-void* operator new(std::type_identity<Foo>, std::size_t); // (1)
-
-struct Bar {
-  static void* operator new(std::size_t); // (2)
+struct SubClass4 : BaseClass1 {
+  void *operator new(size_t); // (6)
 };
 
-void* operator new(std::size_t); // (3)
+void f() {
+  new SingleClass();     // calls (1)
+  new UnrelatedClass();  // calls (2)
+  new BaseClass();       // calls (3) with T=BaseClass
+  new SubClass1();       // calls (3) with T=SubClass1
+  new SubClass2();       // calls (4)
+  new SubClass3();       // resolves (5) reports error due to deleted operator
+  new SubClass4();       // calls (6) as the class scoped allocator wins
+  new int();             // calls (2) with T=int
+}
+```
+
+## In class example
+```cpp
+// In class operator
+class SubClass1;
+struct BaseClass { 
+  template <typename T>
+  void* operator new(std::type_identity<T>, std::size_t); // (1)
+  void* operator new(std::type_identity<SubClass1>, std::size_t); // (2)
+};
+
+struct SubClass1 : BaseClass { };
+struct SubClass2 : BaseClass { };
+struct SubClass3 : BaseClass { 
+  void *operator new(std::size_t); // (3)
+};
+struct SubClass4 : BaseClass { 
+  template <typename T>
+  void *operator new(std::type_identity<T>, std::size_t); // (4)
+};
 
 void f() {
-  new lib::Foo();  // calls (1)
-  new Bar();       // calls (2)
-  new lib::Foo2(); // (1) is seen but fails overload resolution, we end up calling (3)
-  new int();       // calls (3)
+  new BaseClass;         // calls (1) with T=BaseClass
+  new SubClass1();       // calls (2)
+  new SubClass2();       // calls (1) with T=SubClass2
+  new SubClass3();       // calls (3)
+  new SubClass4();       // calls (4) with T=SubClass4
+  ::new BaseClass();     // ingnores in class operators and uses appropriate global operator
 }
 ```
 
@@ -484,5 +508,7 @@ the scope of this proposal.
 
 # Suggested polls
 
-1. Do we want to solve the problem of providing a type aware `operator new` as a free function?
-2. Do we prefer `std::type_identity` before the size and alignment (status quo), or first in the argument list?
+1. Do we agree on the use of `std::type_identity` as the tag type
+2. Do we prefer `std::type_identity` before the size and alignment (status quo), or later in the argument list?
+3. Do we agree that type aware allocators should be accepted as usual deallocation functions
+

--- a/p2719.md
+++ b/p2719.md
@@ -429,44 +429,8 @@ being able to use usual deallocation functions. This is any environment where it
 may throw exceptions, and depend on object clean up, a condition that applies across from many custom "drop in"
 allocator libraries all the way to general system allocators.
 
-<!--
-## Should a templated operator delete be allowed as a usual allocation function?
-
-[dynamic.deallocation#3](https://timsong-cpp.github.io/cppwp/n4950/basic.stc.dynamic.deallocation#3) states that a template function
-is never considered as a usual allocation function. This prevents general allocators from specifying a general type-aware deallocation
-operator that can reflect the correct concrete type when invoking a deleting constructor. e.g.
-
-```cpp
-class Root {
-public:
-  template <class T> static void *operator new(std::size_t, std::type_identity<T>);
-  template <class T> static void operator delete(void *, std::type_identity<T>);
-};
-
-class A : public Root { };
-
-class B : public Root {
-  virtual ~B();
-};
-class C : public B { };
-
-int foo(A* a, B* b, B* c /* actually points to a C object */) {
-  delete a; // We want Root::operator delete<A>(...) to be called
-
-  delete b; // We want Root::operator delete<B> to be called, and that happens via
-            // the deleting virtual destructor.
-            // TODO
-
-  delete c; // The allocator would call the deleting virtual destructor, and expect this to invoke
-            // Root::operator delete<C>
-            // TODO
-}
-```
-
-Allowing a template delete operator to be considered a usual allocation function could result in previously ignored delete declarations being invoked. We could mitigate this risk by constraining the selection of template `usual` allocations to solely allow the typed allocation signatures - the existing selection rules for usual allocation functions already have strict parameter type restrictions on what is required for an allocation function to be usual so this is not wholly without precedence.
--->
 
 # Suggested polls
 
 1. Do we want to solve the problem of providing a type aware `operator new` as a free function?
-2. Do we prefer `std::type_identity` after the size and alignment (status quo), or first in the argument list?
+2. Do we prefer `std::type_identity` before the size and alignment (status quo), or first in the argument list?

--- a/p2719.md
+++ b/p2719.md
@@ -49,8 +49,8 @@ DeclSpace::operator new(sizeof(T), args...)  // (2)
 new (args...) T(...)
 
 // compiler checks:
-DeclSpace::operator new(std::type_identity\<T\>, sizeof(T), align_val_t(alignof(T)), args...) // (1)
-DeclSpace::operator new(std::type_identity\<T\>, sizeof(T)), args...) // (1)
+DeclSpace::operator new(std::type_identity<T>, sizeof(T), align_val_t(alignof(T)), args...) // (1)
+DeclSpace::operator new(std::type_identity<T>, sizeof(T)), args...) // (1)
 DeclSpace::operator new(sizeof(T), align_val_t(alignof(T)), args...) // (1)
 DeclSpace::operator new(sizeof(T), args...)  // (2)
 ```
@@ -58,9 +58,10 @@ DeclSpace::operator new(sizeof(T), args...)  // (2)
 :::
 
 ::: cmptable
-// TODO: Update remainder of examples
+
 ### Before
 ```cpp
+// TODO: Update remainder of examples
 // user writes:
 new (args...) T[n]
 
@@ -72,12 +73,12 @@ T::operator new[](n * sizeof(T), args...) // (1)
 ### After
 ```cpp
 // user writes:
-new (args...) T\[n\];
+new (args...) T[n];
 
 // compiler checks:
-T::operator new\[\](n * sizeof(T), args...) // (1)
-@[operator new\[\](n * sizeof(T), std::type_identity\<T\>, args...)]{.add}@ // (2)
-::operator new\[\](n * sizeof(T), args...)  // (3)
+T::operator new[](n * sizeof(T), args...) // (1)
+@[operator new[](n * sizeof(T), std::type_identity<T>, args...)]{.add}@ // (2)
+::operator new[](n * sizeof(T), args...)  // (3)
 ```
 
 :::
@@ -104,8 +105,8 @@ delete ptr
 // compiler checks:
 // TODO: Myriad align and size parameters
 {{DeclSpace = (T specifies operator new) ? T : Global}}
-DeclSpace::operator delete(std::type_identity\<T\>, T*, destroying_tag_t)
-DeclSpace::operator delete(std::type_identity\<T\>, void-ptr)  // (2)
+DeclSpace::operator delete(std::type_identity<T>, T*, destroying_tag_t)
+DeclSpace::operator delete(std::type_identity<T>, void-ptr)  // (2)
 DeclSpace::operator delete(T*, destroying_tag_t)
 DeclSpace::operator delete(void-ptr)  // (2)
 ```
@@ -113,9 +114,11 @@ DeclSpace::operator delete(void-ptr)  // (2)
 :::
 
 ::: cmptable
-// TODO: Update these
+
 ### Before
 ```cpp
+// TODO: Update these
+
 // user writes:
 delete[] ptr
 
@@ -131,7 +134,7 @@ delete[] ptr
 
 // compiler checks:
 T::operator delete[](void-ptr) // (1)
-@[operator delete[](void-ptr, std::type_identity\<T\>)]{.add}@ // (2)
+@[operator delete[](void-ptr, std::type_identity<T>)]{.add}@ // (2)
 ::operator delete[](void-ptr)  // (3)
 ```
 
@@ -276,9 +279,8 @@ Overload resolution for delete expressions is effectively the same, only with mi
 
 ## Example
 
-// TODO: Update these examples
-
 ```cpp
+// TODO: Update these examples
 namespace lib {
   struct Foo { };
   void* operator new(std::size_t, std::type_identity<Foo>); // (1)

--- a/p2719.md
+++ b/p2719.md
@@ -48,11 +48,11 @@ new (args...) T(...)
 Once determing the source scope and collecting the candidate declarations, the compiler attempts to perform overload
 resolution over the set of candidates in the following order
 
-::: cmptable
-
 <!-- I'm really not sure how to present candidate resolution, i feel it's important to
      explain new/delete don't behave as completely trivial function resolution but have
      a unique "find the best set of implicit parameters first" step -->
+
+::: cmptable
 
 ### Before
 ```cpp
@@ -175,7 +175,7 @@ parameters to include that.
 only dependent parameter is a `std::type_identity` specialization in the first parameter position.
 
 Once a set of candidate declarations has been found we perform the same prioritized overload resolution steps,
-only with the addition of the type_identity tag, with a higher priority than the existing size and alignment 
+only with the addition of the type_identity tag, with a higher priority than the existing size and alignment
 parameters. This gives us the following overload resolution ordering for operator new:
 
 ```cpp
@@ -232,7 +232,7 @@ void f() {
 ```cpp
 // In class operator
 class SubClass1;
-struct BaseClass { 
+struct BaseClass {
   template <typename T>
   void* operator new(std::type_identity<T>, std::size_t); // (1)
   void* operator new(std::type_identity<SubClass1>, std::size_t); // (2)
@@ -240,10 +240,10 @@ struct BaseClass {
 
 struct SubClass1 : BaseClass { };
 struct SubClass2 : BaseClass { };
-struct SubClass3 : BaseClass { 
+struct SubClass3 : BaseClass {
   void *operator new(std::size_t); // (3)
 };
-struct SubClass4 : BaseClass { 
+struct SubClass4 : BaseClass {
   template <typename T>
   void *operator new(std::type_identity<T>, std::size_t); // (4)
 };
@@ -333,7 +333,7 @@ In this proposal we have used `std::type_identity<T>` rather than using the outw
 This perceived simplicity hides an array of subtle problems that are avoided through the use of `std::type_identity`.
 
 ### Problems with the value being passed
-The first problem is the value that is passed as the tag parameter. Given an allocator signature of the form 
+The first problem is the value that is passed as the tag parameter. Given an allocator signature of the form
 
 ```cpp
 template <class T> void *operator new(T*, size_t) { ... }
@@ -443,7 +443,7 @@ definition must be in order to be considered a "usual deallocation function". Th
 not allow template functions previously is because all of the implicit parameters are monomorphic types. In that
 environment such a restriction makes sense.
 
-However in this proposal we have introduced an implicit parameter that for which it is correct, and 
+However in this proposal we have introduced an implicit parameter that for which it is correct, and
 expected, for the method to be templated. To that end we allowed a template `operator delete` to be
 considered a usual deallocation function, as long as the only dependently typed parameter is the implicit
 `type_identity` parameter. To our minds, these semantics match the "intent" of the restrictions already in
@@ -506,7 +506,7 @@ As a result, while the type of the pointer provided to a type aware destroying d
 the concrete type at the point of invocation, the semantics of doing so don't meaningfully change
 from those present in the existing destroying delete specification. As a result we believe that
 extending destroying delete to support subtype dispatch is a more general issue that is outside of
-the scope of this proposal. 
+the scope of this proposal.
 
 ## Design choice: ADL
 

--- a/p2719.md
+++ b/p2719.md
@@ -120,10 +120,10 @@ NEW(sizeof(T), std::align_val_t(alignof(T)), args...)
 If that succeeds, the compiler selects the overload that won. If it does not, the program is ill-formed. For a type `T`
 that has new-extended alignment, the order of the two overload resolutions performed above is simply reversed.
 
-Delete-expressions behave similarly, with lookup being performed in the context of the dynamic type of the object, in
-case it differs from its static type. The overload resolution process then works by preferring a destroying delete,
-followed by an aligned delete (if the type has new-extended alignment), followed by the usual `operator delete` (with
-or without a `size_t` parameter depending on whether the considered `operator delete` is a member function or not).
+Delete-expressions behave similarly, with lookup being performed in the context of the static type of the expression.
+The overload resolution process then works by preferring a destroying delete, followed by an aligned delete (if the
+type has new-extended alignment), followed by the usual `operator delete` (with or without a `size_t` parameter depending
+on whether the considered `operator delete` is a member function or not).
 
 # Proposal
 
@@ -234,6 +234,10 @@ according to usual rules for overload resolution.
 When a constructor throws an exception, a call to `operator delete` is made to clean up. Overload resolution for this
 call remains essentially the same, the only difference being that the selected `operator delete` must have the same
 type-awareness as the preceding `operator new` or the program is considered ill-formed.
+
+For clarity, in types with virtual destructors, `operator delete` is resolved using the destructor's class as the type
+being deallocated (this matches the existing semantics of being equivalent to performing `delete this` in the context
+of the class's non virtual destructor).
 
 ## Free function example
 

--- a/p2719.md
+++ b/p2719.md
@@ -1,7 +1,7 @@
 ---
 title: "Type-aware allocation and deallocation functions"
-document: P2719R0
-date: 2024-05-18
+document: P2719R1
+date: 2024-10-11
 audience: Evolution
 author:
   - name: Louis Dionne
@@ -23,7 +23,7 @@ mechanism exists for _delete-expressions_.
 This paper proposes an extension to _new-expressions_ and _delete-expressions_ to provide the concrete type of an
 allocation or deallocation to the allocation functions. This is achieved via the addition of an additional tag argument
 of type `std::type_identity<TypeBeingAllocated>` that allows the provision of the concrete type to `operator new` and
-`oeprator delete`. This allows the addition of type specific implementations of `operator new` and `operator delete` for
+`operator delete`. This allows the addition of type specific implementations of `operator new` and `operator delete` for
 types that cannot have invasive class scoped allocators specified, and allows accurate type information to be provided
 when allocating subtypes.
 
@@ -88,7 +88,7 @@ T::operator new[](n * sizeof(T), args...) // (1)
 ### Before
 ```cpp
 // user writes:
-delete obj
+delete ptr
 
 // compiler checks:
 // TODO: Myriad align and size parameters
@@ -139,6 +139,16 @@ T::operator delete[](void-ptr) // (1)
 ```
 
 :::
+
+# Revision history
+
+- R0: Initial version
+- R1 (based on St-Louis feedback and implementation experience):
+  - Simplified the lookup mechanism to avoid entangling overload resolution with name lookup
+  - Allowed `std::type_identity` parameter in `operator new` defined at class scope
+  - Modified mechanism to not take into account placement args for ADL (TODO: Explain why in Design section)
+  - TODO: Added justification for taking `std::type_identity<T>` instead of `T*` as a first argument
+  - TODO: Added explanation of what happens w.r.t. ODR and mismatched new/delete operators
 
 # Motivation
 

--- a/p2719.md
+++ b/p2719.md
@@ -401,27 +401,6 @@ pointer parameters, where the explicitly typed parameter is null. However we can
 this parameter as this operator is called after the object has been destroyed, so providing the original pointer
 would be an invitation to guaranteed undefined behaviour.
 
-The confusion is further increased when considering a destroying operator delete
-
-```cpp
-struct Foo {
-  template <class T> void operator delete(T*, Foo *, std::destroying_delete_t) { ... }
-};
-
-struct Bar : Foo { ... };
-
-Bar *bar = ...;
-delete bar;
-// compiler invokes
-Foo::operator delete<Bar>(nullptr, &bar, std::destroying_delete);
-```
-
-In this case the the developer's deletion operator is invoked on an object that has not been
-destroyed, yet the concretely typed parameter is still a null pointer. Allowing the pointer
-to be the object being deleted would lead to the same pointer being passed as two parameters
-which may seem confusing, and introduces an arbitrary difference in the semantics of a parameter
-that is used in the same way in the other operator variants.
-
 ### Problems with implicit capture of subtypes
 
 A scenario we have discussed is developers wishing to provide custom allocators for specific types,

--- a/p2719.md
+++ b/p2719.md
@@ -444,7 +444,7 @@ struct Foo {
 
 We chose not to change the behavior here in order to simplify the semantic impact of this proposal, and
 keep it as close as possible to being just a new implicit parameter for new and delete operators. In
-principle in this model we could extend the proposal to allow
+principle we this proposal could be extended to allow:
 
 ```cpp
 struct Foo {
@@ -453,13 +453,14 @@ struct Foo {
 };
 ```
 
-However we note that the current specification does not allow
+But we note that the current specification also does not allow constructs such as the following:
 
 ```cpp
 struct Bar;
 struct Foo {
-  template <class T> void *operator new(type_identity<T>, size_t);
-  template <class T> void operator delete(type_identity<T>, T *, std::destroying_delete_t);
+  void *operator new(size_t);
+  void operator delete(Foo *, std::destroying_delete_t);
+  void operator delete(Bar *, std::destroying_delete_t);
 };
 struct Bar : Foo { ... };
 ```
@@ -467,9 +468,19 @@ struct Bar : Foo { ... };
 So in addition to the new implicit tag parameter and template argument, this would be introducing
 functionality that is not permitted in the existing language while in priciple being a semantically
 valid option. The authors of this proposal are not aware of the content of discussions when designing
-destroying delete so we do not know if this restriction was the product of techical arguments or
-the limitations of the language at the time, and so extending the behavior and semantics of destroying
-delete seemed out of scope for this proposal.
+destroying delete so we do not know if this restriction was the product of semantic arguments or
+the limitations of the language at the time. An obvious reason for the existing restriction is that
+the existing language has no way to verify a subtype relationship between types at the point the
+delete operator is declared, and fundamentally that restriction does not change with this proposal.
+A concretely typed destroying delete would have the same problem, and it is only by the delayed
+instantiation enabled by use of templates that the subtyping restriction could be enforced in our
+proposal.
+
+As a result, while the type of the pointer provided to a type aware destroying delete could be
+the concrete type at the point of invocation, the semantics of doing so don't meaningfully change
+from those present in the existing destroying delete specification. As a result we believe that
+extending destroying delete to support subtype dispatch is a more general issue that is outside of
+the scope of this proposal. 
 
 # Suggested polls
 

--- a/p2719.md
+++ b/p2719.md
@@ -22,64 +22,53 @@ mechanism exists for _delete-expressions_.
 
 This paper proposes an extension to _new-expressions_ and _delete-expressions_ to provide the concrete type being
 [de]allocated to the allocation functions. This is achieved via the addition of an additional `std::type_identity<T>`
-tag argument that allows the provision of the concrete type to `operator new` and `operator delete`. This allows the
-creation of type-specific `operator new` and `operator delete` for types that cannot have intrusive class-scoped
-operators specified, and allows accurate type information to be provided when allocating subtypes.
+tag argument that allows the provision of the concrete type to `operator new` and `operator delete`. In addition to
+providing valuable information to the allocator, this allows the creation of type-specific `operator new` and
+`operator delete` for types that cannot have intrusive class-scoped operators specified.
 
-The following describes (roughly) the search process performed by the compiler before and after this paper:
+<!-- I think the following should just be moved down to how things work section -->
+
+When evaluating a new or delete expression, the compiler first finds the set of candidate declarations of the required
+operator name. When operating on non class types only the global scope is searched. If operating on a class type, we
+first search the class scope for the requested operator names, and only if no declarations of the correct name are
+found do we then include the global scope in our search space.
+
+Once the candidates are found, we perform overload resolution on the candidates over the language specified optional
+implicit parameters, and if present any developer provided placement arguments. This proposal introduces a new optional
+implicit parameter, that has higher priority than all existing implicit parameters, and as such changes overload
+resolution ordering.
+
+At a high level the operator resolution changes as follows
+
+```cpp
+// user writes:
+new (args...) T(...)
+```
+
+Once determing the source scope and collecting the candidate declarations, the compiler attempts to perform overload
+resolution over the set of candidates in the following order
 
 ::: cmptable
 
 ### Before
 ```cpp
-// user writes:
-new (args...) T(...)
-
-// compiler checks:
-operator new(size_t, align_val_t, args...)
-operator new(size_t, args...)
+Candidate(size_t, align_val_t, args...)
+Candidate(size_t, args...)
 ```
 
 ### After
 ```cpp
-// user writes:
-new (args...) T(...)
-
 // compiler checks:
-@[operator new(type_identity<T>, size_t, align_val_t, args...)]{.add}@
-@[operator new(type_identity<T>, size_t, args...)]{.add}@
-operator new(size_t, align_val_t, args...)
-operator new(size_t, args...)
+@[Candidate(type_identity<T>, size_t, align_val_t, args...)]{.add}@
+@[Candidate(type_identity<T>, size_t, args...)]{.add}@
+Candidate(size_t, align_val_t, args...)
+Candidate(size_t, args...)
 ```
 
 :::
 
-::: cmptable
-
-### Before
-```cpp
-// user writes:
-delete ptr
-
-// compiler checks:
-// OLIVER: TODO: Add other overloads
-// OLIVER: TODO: Check how delete operators are prefered
-operator delete(T*, destroying_delete_t)
-operator delete(void-ptr)
-```
-
-### After
-```cpp
-// user writes:
-delete ptr
-
-// compiler checks:
-// OLIVER: TODO: Add other overloads
-@[operator delete(type_identity<T>, T*, destroying_delete_t)]{.add}@
-@[operator delete(type_identity<T>, void-ptr)]{.add}@
-operator delete(T*, destroying_tag_t)
-operator delete(void-ptr)
-```
+Resolution ordering for _delete-expressions_ matches that of _new-expressions_, only with minor changes to incorporate
+additional implicit parameters.
 
 :::
 
@@ -100,35 +89,36 @@ operator delete(void-ptr)
 # Motivation
 
 Knowledge of the type being allocated in a _new-expression_ is necessary in order to achieve certain levels of flexibility
-when defining a custom allocation function. However, requiring an intrusive in-class definition to achieve this is not
-realistic in various circumstances, for example when wanting to customize allocation for types that are controlled by a
-third-party, or when customizing allocation for a very large number of types. Even when in-class definitions are an option,
-the existing specification does not provide a mechanism to support concrete type information when allocating and deallocating
-subtypes.
+and security when defining a custom allocation function. Even when using in-class definitions, the only information
+available to the implementation is the type declaring the operator, and subclasses remain opaque. This results in
+developers using extensively copy-pasted macros to try construct the require allocation functions manually, or having to
+completely circumvent the language provided new and delete expressions in order to track the allocated types.
 
-In the wild, we often see code bases overriding the global (and untyped) `operator new` via the usual link-time mechanism
-and running into issues because they really only intended for their custom `operator new` to be used within their own code,
-not by all the code in their process. We also run into issues where multiple libraries attempt to replace the global
-`operator new` and end up with a complex ODR violation bug.
+Beyond exposing concrete allocation type to an allocator, a common problem in we see in the wild, are codebases overriding
+the global (and untyped) `operator new` via the usual link-time mechanism and running into issues because they really only
+intended for their custom `operator new` to be used within their own code, not by all the code in their process. We also
+run into issues where multiple libraries attempt to replace the global `operator new` and end up with a complex ODR
+violation bug. By providing the concrete type information to allocators at compile time it becomes possible for authors
+to restrict their allocator definitions to just the types for which they are intended.
 
 The changes proposed by this paper provide a mechanism for code bases to implement smarter and more secure allocators,
-and to more easily implement what they _actually_ want, which is to override `operator new` for a family of types that they
-control without overriding it for the whole process. The overriding also happens at compile-time instead of link-time, which
-is both supported by all known implementations (unlike link-time) and better understood by users than e.g. weak definitions.
+and to more easily implement what they _actually_ want, which is to override `operator new` for a family of types that
+they control without overriding it for the whole process.
 
 ## A concrete use case
 
 A few years ago, Apple published [a blog post](https://security.apple.com/blog/towards-the-next-generation-of-xnu-memory-safety)
-explaining a technique used inside its kernel (XNU) to mitigate various exploits. At its core, the technique roughly consists in
-allocating objects of each type in a different bucket. By collocating all objects of the same type into the same region of
-memory, it becomes much harder for an attacker to exploit a type confusion vulnerability. Since its introduction in the kernel,
-this technique alone has been by far the most effective at mitigating type confusion vulnerabilities.
+explaining a technique used inside its kernel (XNU) to mitigate various exploits. At its core, the technique roughly
+consists in allocating objects of each type in a different bucket. By collocating all objects of the same type into the
+same region of memory, it becomes much harder for an attacker to exploit a type confusion vulnerability. Since its
+introduction in the kernel, this technique alone has been by far the most effective at mitigating type confusion
+vulnerabilities.
 
 In a world where security is increasingly important, it may make sense for some code bases to adopt mitigation techniques
 such as this one. However, these techniques require a large-scale and _almost_ system-wide customization of how allocation
 is performed while retaining type information, which is not supported by C++ today. While not sufficient in itself to make
-C++ safer, the change proposed in this paper is a necessary building block for technology such as the above which can greatly
-improve the security of C++ applications.
+C++ safer, the change proposed in this paper is a necessary building block for technology such as the above which can
+greatly improve the security of C++ applications.
 
 # Current behavior recap
 
@@ -165,45 +155,26 @@ or without a `size_t` parameter depending on whether the considered `operator de
 
 This proposal adds a new implicit tag argument of type `std::type_identity<T>` to `operator new` and `operator delete` that
 is incorporated into the existing declaration preference logic with a higher priority than existing implicit parameters.
-To avoid potential conficts with existing code, this parameter is placed as the first argument to the operator, preceding
-the size or subject pointer. For such a declaration to be valid we require that the parameter be explicitly a specialization
-of `std::type_identity`, and not a fully dependent type.
+To avoid conficts with existing code, this parameter is placed as the first argument to the operator, preceding the size or
+subject pointer. For such a declaration to be valid we require that the parameter be explicitly a specialization
+of `std::type_identity`, and not a fully dependent type. This is analogous to the current specification behavior requiring
+specific concrete types in the parameter list, even in dependent contexts, only with the caveat that for the purpose of this
+proposal the type parameters applied to the `std::type_identity` tag necessarily may be dependent.
 
-<!--
-Terminology question:
-i'm wanting to say these are correct:
-void* operator new(std::type_identity<Foo>, size_t, ...);
-template <typename T> void* operator new(std::type_identity<T>, size_t, ...);
-template <typename T> void* operator new(std::type_identity<Foo<T>>, size_t, ...);
+To simplify the text we will refer to an allocation operator in which the first parameter is a specialization of
+`std::type_identity` as being a "type aware allocator", regardless of whether the specialized tag type is dependent or not.
 
-but these are not:
+To effectively support this new tag it is necessary to update the definition of a usual deallocation function
+([basic.stc.dynamic.deallocation]) to include this new parameter, which requires the following:
 
-template <typename T> void* operator new(T, size_t, ...); // even if invoked with `operator new<type_identity<int>>`
-template <typename T> struct S { void* operator new(T, size_t, ...); }; S<std::type_identity<int>>
-template <template<typename> typename T> void* operator new(T<int>, size_t, ...); // even if invoked with `operator new<std::type_identity>
-etc
--->
+* Allow the first parameter to be a specialization of type_identity, and update to position requirements of later
+parameters to include that.
+* Allow the function to have template parameters as long as the function is a type aware `operator delete` and the
+only dependent parameter is a `std::type_identity` specialization in the first parameter position.
 
-We will refer to operator new and delete declarations of this form as "type aware allocation operators".
-
-To reduce leakage into the global scope, this proposal now allows type aware allocation operators to be declared within
-a namespace. **Note: i feel we should be able to specify semantics such that `new X` and `delete someX` require the
-resolved operator new and delete come from the same scope as at least a basic correctness guard**
-
-
-Currently during operator resolution, if no in-class declaration is discovered we continue our search in the global scope.
-In our proposal if no in-class declaration of the requested operator is found we replace the current global scope look up
-with an ADL lookup over the implicit parameters.
-
-
-To effectively support this new tag it is necessary to update the definition of a usual deallocation function ([basic.stc.dynamic.deallocation]) to:
-
-* Allow type aware allocation operators. This means allowing the `std::type_identity` parameter, and updating the current spec text to allow for the change in later parameter positions
-* Allow the operator to have template arguments, as long as the only the first parameter is dependent, and it is type aware operator.
-
-Once a set of candidate declarations has been found we perform the same priorities overload resolution steps, only with
-the addition of the type_identity tag, with a higher priority than the existing size and alignment parameters. This gives
-us the following overload resolution ordering for operator new:
+Once a set of candidate declarations has been found we perform the same prioritized overload resolution steps,
+only with the addition of the type_identity tag, with a higher priority than the existing size and alignment 
+parameters. This gives us the following overload resolution ordering for operator new:
 
 ```cpp
 1. NEW(type_identity<T>, size_t, align_val_t, args...)

--- a/p2719.md
+++ b/p2719.md
@@ -26,86 +26,55 @@ tag argument that allows the provision of the concrete type to `operator new` an
 providing valuable information to the allocator, this allows the creation of type-specific `operator new` and
 `operator delete` for types that cannot have intrusive class-scoped operators specified.
 
-<!-- I think the following should just be moved down to how things work section -->
-
-When evaluating a new or delete expression, the compiler first finds the set of candidate declarations of the required
-operator name. When operating on non class types only the global scope is searched. If operating on a class type, we
-first search the class scope for the requested operator names, and only if no declarations of the correct name are
-found do we then include the global scope in our search space.
-
-Once the candidates are found, we perform overload resolution on the candidates over the language specified optional
-implicit parameters, and if present any developer provided placement arguments. This proposal introduces a new optional
-implicit parameter, that has higher priority than all existing implicit parameters, and as such changes overload
-resolution ordering.
-
-At a high level the operator resolution changes as follows
+At a high level, this allows defining allocation and deallocation functions like:
 
 ```cpp
-// user writes:
-new (args...) T(...)
+void* operator new(std::type_identity<mylib::Foo>, std::size_t n) { ... }
+void operator delete(std::type_identity<mylib::Foo>, void* ptr) { ... }
 ```
 
-Once determing the source scope and collecting the candidate declarations, the compiler attempts to perform overload
-resolution over the set of candidates in the following order
+However, it also allows providing these functions for a family of types, which is where this feature becomes
+interesting:
 
-<!-- I'm really not sure how to present candidate resolution, i feel it's important to
-     explain new/delete don't behave as completely trivial function resolution but have
-     a unique "find the best set of implicit parameters first" step -->
-
-::: cmptable
-
-### Before
 ```cpp
-Candidate(size_t, align_val_t, args...)
-Candidate(size_t, args...)
+template <class T>
+  requires has_type_segregation_requirement<T>
+void* operator new(std::type_identity<T>, std::size_t n) { ... }
+
+template <class T>
+  requires has_type_segregation_requirement<T>
+void operator delete(std::type_identity<T>, void* ptr) { ... }
 ```
-
-### After
-```cpp
-// compiler checks:
-@[Candidate(type_identity<T>, size_t, align_val_t, args...)]{.add}@
-@[Candidate(type_identity<T>, size_t, args...)]{.add}@
-Candidate(size_t, align_val_t, args...)
-Candidate(size_t, args...)
-```
-
-:::
-
-Resolution ordering for _delete-expressions_ matches that of _new-expressions_, only with minor changes to incorporate
-additional implicit _destroying_ and _size_ parameters.
-
-:::
 
 # Revision history
 
 - R0: Initial version
 - R1 (based on St-Louis feedback and implementation experience):
   - Simplified the lookup mechanism by removing the need to perform ADL
-  - Allowed `std::type_identity` parameter in `operator new` defined at class scope for consistency
+  - Allowed `std::type_identity` parameter for in-class `T::operator new` for consistency
   - LOUIS: TODO: Added justification for taking `std::type_identity<T>` instead of `T*` as a first argument.
   - LOUIS: TODO: Added explanation of what happens w.r.t. ODR and mismatched new/delete operators
   - LOUIS: TODO: Mention interactions with `std::allocator` and that we can resolve that separately
 
-<!-- OLIVER TODO: Make sure it renders nicely -->
-
 # Motivation
 
-Knowledge of the type being allocated in a _new-expression_ is necessary in order to achieve certain levels of flexibility
-and security when defining a custom allocation function. Even when using in-class definitions, the only information
-available to the implementation is the type declaring the operator, and subclasses remain opaque. This results in
-developers using extensively copy-pasted macros to try construct the require allocation functions manually, or having to
-completely circumvent the language provided new and delete expressions in order to track the allocated types.
+Knowledge of the type being [de]allocated in a _new-expression_ is necessary in order to achieve certain levels of
+flexibility when defining a custom allocation function. However, even when defining `T::operator new` in-class, the
+only information available to the implementation is the type declaring the operator, not the type being allocated.
+This results in developers various creative (often macro-based) mechanisms to define these allocation functions manually,
+or circumventing the language-provided allocation mechanisms entirely in order to track the allocated types.
 
-Beyond exposing concrete allocation type to an allocator, a common problem in we see in the wild, are codebases overriding
-the global (and untyped) `operator new` via the usual link-time mechanism and running into issues because they really only
-intended for their custom `operator new` to be used within their own code, not by all the code in their process. We also
-run into issues where multiple libraries attempt to replace the global `operator new` and end up with a complex ODR
-violation bug. By providing the concrete type information to allocators at compile time it becomes possible for authors
-to restrict their allocator definitions to just the types for which they are intended.
+However, in addition to these intrusive mechanisms being cumbersome and error-prone, they do not make it possible to
+customize how allocation is performed for types controlled by a third-party, or to customize allocation for an open
+set of types.
 
-The changes proposed by this paper provide a mechanism for code bases to implement smarter and more secure allocators,
-and to more easily implement what they _actually_ want, which is to override `operator new` for a family of types that
-they control without overriding it for the whole process.
+Beyond these issues, a common problem in we see in the wild is codebases overriding the global (and untyped) `operator new`
+via the usual link-time mechanism and running into problems because they really only intended for their custom
+`operator new` to be used within their own code, not by all the code in their process. For example, we've seen scenarios
+where multiple libraries attempt to replace the global `operator new` and end up with a complex ODR violation bug that
+depends on how the dynamic linker resolved weak definitions at load time -- not very user friendly. By providing the
+concrete type information to allocators at compile time, it becomes possible for authors to override `operator new`
+for a family of types that they control without overriding it for the whole process, which is what they _actually_ want.
 
 ## A concrete use case
 
@@ -127,12 +96,14 @@ greatly improve the security of C++ applications.
 Today, the compiler performs [a lookup](https://timsong-cpp.github.io/cppwp/n4950/expr.new#12) in the allocated type's class
 scope (for `T::operator new`), and then a lookup in the global scope (for `::operator new`) if the previous one failed. Once
 the name lookup has been done and the compiler has decided whether it was looking for `T::operator new` or `::operator new`,
-name lookup will not be done again even if the steps that follow were to fail.
+name lookup will not be done again even if the steps that follow were to fail. From here on, let's denote by `NEW` the
+set of candidates found by the name lookup process.
 
-The compiler then performs [overload resolution](https://timsong-cpp.github.io/cppwp/n4950/expr.new#19) on the name it found
-in the previous step (let's call that name `NEW`) by assembling an argument list that depends on whether `T` has a new-extended
-alignment or not. For the sake of simplicity, assume that `T` does not have a new-extended alignment. The compiler starts by
-performing overload resolution as-if the following expression were used:
+The compiler then performs [overload resolution](https://timsong-cpp.github.io/cppwp/n4950/expr.new#19) on that set of
+candidates using the language-specified optional implicit parameters, and if present any developer-provided placement
+arguments. It does so by assembling an argument list that depends on whether `T` has a new-extended alignment or not.
+For the sake of simplicity, assume that `T` does not have a new-extended alignment. The compiler starts by performing
+overload resolution as-if the following expression were used:
 
 ```cpp
 NEW(sizeof(T), args...)
@@ -155,45 +126,109 @@ or without a `size_t` parameter depending on whether the considered `operator de
 
 # Proposal
 
-This proposal adds a new implicit tag argument of type `std::type_identity<T>` to `operator new` and `operator delete` that
-is incorporated into the existing declaration preference logic with a higher priority than existing implicit parameters.
+This proposal adds a new implicit tag argument of type `std::type_identity<T>` to `operator new` and `operator delete`
+that is incorporated into the existing overload resolution logic with a higher priority than existing implicit parameters.
 To avoid conficts with existing code, this parameter is placed as the first argument to the operator, preceding the size or
-subject pointer. For such a declaration to be valid we require that the parameter be explicitly a specialization
-of `std::type_identity`, and not a fully dependent type. This is analogous to the current specification behavior requiring
-specific concrete types in the parameter list, even in dependent contexts, only with the caveat that for the purpose of this
-proposal the type parameters applied to the `std::type_identity` tag necessarily may be dependent.
-
-To simplify the text we will refer to an allocation operator in which the first parameter is a specialization of
-`std::type_identity` as being a "type aware allocator", regardless of whether the specialized tag type is dependent or not.
-
-To effectively support this new tag it is necessary to update the definition of a usual deallocation function
-([basic.stc.dynamic.deallocation]) to include this new parameter, which requires the following:
-
-* Allow the first parameter to be a specialization of type_identity, and update to position requirements of later
-parameters to include that.
-* Allow the function to have template parameters as long as the function is a type aware `operator delete` and the
-only dependent parameter is a `std::type_identity` specialization in the first parameter position.
+subject pointer. To avoid the complexities of ADL, this proposal does not change any of the _name lookup_ rules associated
+to _new_ and _delete_ expressions: it only changes the overload resolution that happens once a name has been found.
 
 Once a set of candidate declarations has been found we perform the same prioritized overload resolution steps,
-only with the addition of the type_identity tag, with a higher priority than the existing size and alignment
-parameters. This gives us the following overload resolution ordering for operator new:
+only with the addition of `std::type_identity<T>`, with a higher priority than the existing size and alignment
+parameters. For illustration, here is how overload resolution changes (`NEW` is the set of candidates found by
+name lookup for `operator new`, and `DELETE` is the equivalent for `operator delete`):
+
+::: cmptable
+
+> User writes `new T(...)`, compiler checks (in order):
+
+### Before
 
 ```cpp
-1. NEW(type_identity<T>, size_t, align_val_t, args...)
-2. NEW(type_identity<T>, size_t, args...)
-3. NEW(size_t, align_val_t, args...)
-4. NEW(size_t, args...)
+// assuming T not overaligned
+NEW(size_t)
 ```
 
-If multiple candidates match a given set of parameters, then operator prioritisation and selection is performed
-according to standard constraint precedence rules.
+### After
 
-When a constructor throws an exception, a cleanup call is made to `operator delete`. The semantics of this cleanup
-resolution remain essentially the same, the only difference being that the `operator delete` selected during overload
-resolution must have the same type awareness as the preceding `operator new` or the program is considered ill formed.
+```cpp
+// assuming T not overaligned
+NEW(type_identity<T>, size_t)
+NEW(size_t)
+```
 
-Overload resolution for delete expressions is effectively the same, only with minor variations on the implicit
-parameter types.
+---
+
+```cpp
+// assuming T overaligned
+NEW(size_t, align_val_t)
+NEW(size_t)
+```
+
+```cpp
+// assuming T overaligned
+NEW(type_identity<T>, size_t, align_val_t)
+NEW(type_identity<T>, size_t)
+NEW(size_t, align_val_t)
+NEW(size_t)
+```
+
+:::
+
+::: cmptable
+
+> User writes `delete ptr`, compiler checks (in order):
+
+### Before
+
+```cpp
+// assuming T not overaligned
+DELETE(T*, destroying_delete_t, ...)
+DELETE(void*, size_t)
+DELETE(void*)
+```
+
+### After
+
+```cpp
+// assuming T not overaligned
+DELETE(T*, destroying_delete_t, ...)
+DELETE(type_identity<T>, void*, size_t)
+DELETE(type_identity<T>, void*)
+DELETE(void*, size_t)
+DELETE(void*)
+```
+
+---
+
+```cpp
+// assuming T overaligned
+DELETE(T*, destroying_delete_t, ...)
+DELETE(void*, size_t, align_val_t)
+DELETE(void*, align_val_t)
+DELETE(void*)
+```
+
+```cpp
+// assuming T overaligned
+DELETE(T*, destroying_delete_t, ...)
+DELETE(type_identity<T>, void*, size_t, align_val_t)
+DELETE(type_identity<T>, void*, align_val_t)
+DELETE(type_identity<T>, void*)
+DELETE(void*, size_t, align_val_t)
+DELETE(void*, align_val_t)
+DELETE(void*)
+```
+
+:::
+
+If multiple candidates match a given set of parameters, candidate prioritisation and selection is performed
+according to usual rules for overload resolution.
+
+When a constructor throws an exception, a call to `operator delete` is made to clean up. Overload resolution for this
+call remains essentially the same, the only difference being that the selected `operator delete` must have the same
+type-awareness as the preceding `operator new` or the program is considered ill-formed.
+
+<!-- LOUIS: stopped here -->
 
 ## Free function example
 
@@ -257,6 +292,25 @@ void f() {
   ::new BaseClass();     // ingnores in class operators and uses appropriate global operator
 }
 ```
+
+# Wording
+
+<!-- TODO: finish -->
+To simplify the text, we will refer to an allocation operator in which the first parameter is a specialization of
+`std::type_identity` as being a "type aware [de]allocation operator". For the declaration of a type aware [de]allocation
+operator to be valid, we explicitly require that the parameter be a (potentially dependent) specialization of
+`std::type_identity`, but not a fully dependent type. In other words, the compiler must be able to tell that the
+first parameter is of the form `std::type_identity<T>` at the time of parsing the declaration, but before the declaration
+has been instantiated in the case of a template. This is analogous to the current behavior where we require specific
+concrete types in the parameter list even in dependent contexts.
+
+To effectively support this new tag, it is necessary to update the definition of a usual deallocation function
+([basic.stc.dynamic.deallocation]) to include this new parameter, which requires the following:
+
+* Allow the first parameter to be a specialization of type_identity, and update to position requirements of later
+parameters to include that.
+* Allow the function to have template parameters as long as the function is a type aware `operator delete` and the
+only dependent parameter is a `std::type_identity` specialization in the first parameter position.
 
 # Design choices and notes
 


### PR DESCRIPTION
Apparently I was editing an out of date version of the proposal because git fights me, so this is overwriting a bunch of stuff that may be inappropriate at this point. Just pushing this up so we have a shared context to discuss the variation. I will look into trying to update it more cleanly this evening. In the mean time this is just a semi-edit, semi-rambling set of changes to consider.

The general gist of the changes that I think make sense

- We revert to type_identity_t as the first parameter, as that guarantees no conflict with existing code using variadic template new/delete
- We allow in-class definition of type aware allocators. Multiple groups I've talked to found the disallowing of in-class look up to be obnoxious - their most common use cases are class hierarchies, so free function versions of this require introduction of constraints, and no static guarantees that the best matching new/delete operators will come from the same definitions. At least one group also wanted type aware destroying delete, and I think destroying delete is class scoped?
- Remove the fallback if match fails path, just allowing in-class type aware new+delete resolves the issue of "how do we get type aware operators when there are in-class operators?", and it resolves issues where enabling a type aware new/delete may trigger resolution of a free type aware new/delete in some cases and class scoped operators in other cases.
- ADL should only be performed over the implicit arguments, not the full set of placement args as that results in potentially terrible resolution semantics with delete
- To avoid leaking objects in existing code we need type aware operator delete to be considered a usual deallocation function, so we allow the type_identity_t parameter in the correct location, and we allow templated operator delete as a usual deallocation function if (and only if) the type_identity_t parameter is dependent.
- Try to make it clear that these operators are only valid if the type tag is an explicit instantiation of std::type_identity_t, e.g. the parameter must be `std::type_identity_t<T>` where `T` can be a concrete type, a template parameter, or some other dependent type, but something like `template <typename T> struct S { void *operator new(T, size_t); }; S<type_identity_t<int>> s;` is not valid.

