### PR TITLE
P3516R3: pre-Brno mailing

### DIFF
--- a/p3516.md
+++ b/p3516.md
@@ -1,8 +1,8 @@
 ---
 title: "Uninitialized algorithms for relocation"
-document: P3516R2
-date: 2025-02-13
-audience: LWG
+document: P3516R3
+date: 2026-05-04
+audience: LEWG
 author:
   - name: Louis Dionne
     email: <ldionne.2@gmail.com>
@@ -14,6 +14,25 @@ toc-depth: 2
 
 # Changelog
 
+- R3 (LEWG, pre-Brno)
+    - R1 of this paper has been reviwed by LEWG in Hagenberg and forwarded to LWG (10/12/5/0/0)
+      with minor modifications (merged in R2).
+      In R3 we are going back to LEWG after the removal of trivial relocation from the C++26 WD.
+      Amongst other things, this caused some minor API changes. We would like to have LEWG
+      review the paper again and re-approve the direction.
+      The overall design of the paper has not changed.
+    - Added `is_nothrow_relocatable`, originally merged in the WD as part of [P2786][].
+      The trait has since been removed, so we need to add it ourselves.
+    - Reimplemented `relocate_at` to just use move and destroy,
+      since there is no longer a notion of (trivial) relocation in the language.
+    - Reworded the parallel range overloads, following the adoption of [P3179][].
+    - Removed the parallel backward algorithms. [P3179][]'s design calls for
+      a complete lack of overlap between the source and the destination ranges
+      of parallel algorithms;
+      this makes the parallel backward overloads pointless to have
+      (just use the "normal" ones).
+    - Rebased wording on top of the latest draft; renamed the parameters
+      to match e.g. `std::copy` in the current WD.
 - R2 (LWG in Hagenberg)
     - Make _relocate-at_ part of the API
     - Add `std::execution_policy` overloads for the `ranges::` variants
@@ -26,8 +45,9 @@ toc-depth: 2
 
 # Introduction
 
-[P2786][] is currently making progress through EWG and LEWG. In Poland, LEWG expressed a strong desire for
-that language feature to come with a proper user-facing library interface. This paper proposes such an
+During the C++26 standardization cycle, [P2786][] ("Trivial Relocation for C++26") was merged
+to the Working Draft, but subsequently removed due to a number of design concerns.
+In Poland LEWG expressed a strong desire for a library interface. This paper proposes such an
 interface. That interface is heavily influenced by the uninitialized algorithms that were originally
 proposed in [P1144][] which, after implementation experience in libc++, seem to be almost exactly what
 we need.
@@ -35,7 +55,7 @@ we need.
 This paper aims to provide the high-level algorithms that all programmers will want to use, while purposefully
 not touching on some of the more contentious design points of [P2786][]/[P1144][]. The high-level algorithms
 proposed in this paper are compatible with essentially any definition of "trivial relocation" we might
-introduce in the language in C++26 or later.
+introduce in the language in C++29 or later.
 
 # Motivation
 
@@ -62,6 +82,16 @@ language feature.
 
 Design points:
 
+- The key entry point is the `std::relocate_at` function, which relocates one object. All the
+  algorithms are specified in terms of calls to this function. At the moment the function
+  relocates via move construction at the destination, followed by destruction of the source;
+  when and if C++ will get a notion of (trivial) relocation in the language,
+  it will suffice to extend the semantics of the `relocate_at` function to also
+  perform such (trivial) relocation, using whatever facilities are going to be standardized for this.
+  The major benefit of this approach is that the specification and the semantics of the algorithms
+  themselves will require no changes;
+  by extension, all user code that is built on top of the algorithms will also *automatically* benefit
+  from languge relocation.
 - These functions behave similarly to the other uninitialized algorithms like `std::uninitialized_copy`, with
   the difference that the new proposed relocation algorithms support overlapping input/output ranges like
   `std::move` and `std::move_backward`. That is necessary in order to support most use cases where one
@@ -434,22 +464,15 @@ Performance comparison
 
 # Compatibility with relocation proposals
 
-The current version of the proposal is based on [P2786][] trivial relocation
-library APIs, as approved (with modifications) by LEWG during the 2025-01-14 meeting.
-
-In general it's worth noting that our specification can be easily extended to
+It's worth noting that our specification can be easily extended to
 a future notion of language relocation; the algorithms themselves won't need
 to change; only the proposed exposition-only entities and the proposed
-`relocate_at` function template will need centralized
-fixes. We consider this a major feature of the proposed design.
+`relocate_at` function template and the `is_nothrow_relocatable` type trait
+will need centralized fixes.
+We consider this a major feature of the proposed design.
 
 
 # Wording
-
-**Note**: the following wording assumes that [P2786][] (as approved with
-modifications by LEWG, see above) has already been merged. We are also using
-the entities introduced by [P3179][] in the specification of the parallel
-range algorithms.
 
 ## [version.syn]
 
@@ -459,6 +482,41 @@ Modify the feature-testing macro for `__cpp_lib_raw_memory_algorithms` to match 
 -#define __cpp_lib_raw_memory_algorithms             202411L // also in <memory>
 +#define __cpp_lib_raw_memory_algorithms             ??????L // also in <memory>
 ```
+
+## [meta]
+
+Modify [meta.type.synop]{.sref} as shown:
+
+```diff
+template<class T> struct is_nothrow_destructible;
+
++template<class T> struct is_nothrow_relocatable;
+
+template<class T> struct is_implicit_lifetime;
+```
+
+```diff
+
+template<class T>
+  constexpr bool is_nothrow_destructible_v = is_nothrow_destructible<T>::value;
++template<class T>
++  constexpr bool is_nothrow_relocatable_v = is_nothrow_relocatable<T>::value;
+template<class T>
+  constexpr bool is_implicit_lifetime_v = is_implicit_lifetime<T>::value;
+```
+
+Extend Table [tab:meta.unary.prop]{.sref} as shown:
+
+::: add
+
++---------------------------------------------------+----------------------------------------------------------------------+--------------------------------------------------------------------------+
+| Template                                          | Condition                                                            | Preconditions                                                            |
++===================================================+======================================================================+==========================================================================+
+|`template<class T> struct is_nothrow_relocatable;` | `is_nothrow_move_constructible_v<T> && is_nothrow_destructible_v<T>` | `T` shall be a complete type, *cv* `void`, or an array of unknown bound. |
++---------------------------------------------------+----------------------------------------------------------------------+--------------------------------------------------------------------------+
+
+
+:::
 
 ## [algorithms.requirements]
 
@@ -471,6 +529,7 @@ Modify [algorithms.requirements]{.sref} as shown:
 - [4.?]{.pnum} If an algorithm's template parameter is named `BidirectionalIterator`, `BidirectionalIterator1`, [or ]{.rm} `BidirectionalIterator2`, [`NoThrowBidirectionalIterator1`, or `NoThrowBidirectionalIterator2`,]{.add} the template argument shall meet the *Cpp17BidirectionalIterator* requirements ([bidirectional.iterators]) if it is required to be a mutable iterator, or model `bidirectional_iterator` ([iterator.concept.bidir]) otherwise.
 - [4.?]{.pnum} If an algorithm's template parameter is named `RandomAccessIterator`, `RandomAccessIterator1`, or `RandomAccessIterator2`, the template argument shall meet the *Cpp17RandomAccessIterator* requirements ([random.access.iterators]) if it is required to be a mutable iterator, or model `random_access_iterator` ([iterator.concept.random.access]) otherwise.
 - [4.?]{.pnum} [If an algorithm's template parameter is named `NoThrowForwardIterator`, `NoThrowForwardIterator1`, `NoThrowForwardIterator2`, `NoThrowBidirectionalIterator1`, or `NoThrowBidirectionalIterator2`, the template argument is also required to have the property that no exceptions are thrown from increment, decrement, assignment, or comparison of, or indirection through, valid iterators.]{.add}
+
 
 ## [specialized.algorithms.general]
 
@@ -485,7 +544,7 @@ Modify [specialized.algorithms.general]{.sref} as shown:
 ...
 
 - [4]{.pnum} Some algorithms specified in [specialized.algorithms] make use of the [exposition-only function
-  template _`voidify`_]{.rm} [following exposition-only entities]{.add}:
+  templates]{.rm} [following exposition-only entities]{.add}:
 
 ```diff
 template<class T>
@@ -493,10 +552,17 @@ template<class T>
     return addressof(obj);
   }
 
+template<class I>
+  constexpr decltype(auto) @_deref-move_@(I& it) {
+    if constexpr (is_lvalue_reference_v<decltype(*it)>)
+      return std::move(*it);
+    else
+      return *it;
+  }
+
 +template<class Source, class Dest>
 + concept @_relocatable-from_@ =
-+   same_as<Source, Dest> &&
-+   (move_constructible<Dest> || is_trivially_relocatable_v<Dest>);
++   same_as<Source, Dest> && move_constructible<Dest>;
 +
 +template<class T>
 + requires move_constructible<T>
@@ -511,8 +577,6 @@ template<class T>
 ## [memory.syn]
 
 In [memory.syn]{.sref}, add to the `<memory>` header synopsis (after `[specialized.construct]`):
-
-[This wording uses some of the exposition-only concepts that are added by D3179R8.]{.draftnote}
 
 ```c++
 // [specialized.relocate], relocate_at
@@ -532,8 +596,8 @@ template<class NoThrowForwardIterator1, class NoThrowForwardIterator2>
                            NoThrowForwardIterator2 result);
 
 template<class ExecutionPolicy, class NoThrowForwardIterator1, class NoThrowForwardIterator2>
-  constexpr NoThrowForwardIterator2
-    uninitialized_relocate(ExecutionPolicy&& exec,                                // see [algorithms.parallel.overloads]
+  NoThrowForwardIterator2
+    uninitialized_relocate(ExecutionPolicy&& exec,                                // freestanding-deleted, see [algorithms.parallel.overloads]
                            NoThrowForwardIterator1 first,
                            NoThrowForwardIterator1 last,
                            NoThrowForwardIterator2 result);
@@ -545,8 +609,8 @@ template<class NoThrowForwardIterator1, class Size, class NoThrowForwardIterator
                              NoThrowForwardIterator2 result);
 
 template<class ExecutionPolicy, class NoThrowForwardIterator1, class Size, class NoThrowForwardIterator2>
-  constexpr pair<NoThrowForwardIterator1, NoThrowForwardIterator2>
-    uninitialized_relocate_n(ExecutionPolicy&& exec,                              // see [algorithms.parallel.overloads]
+  pair<NoThrowForwardIterator1, NoThrowForwardIterator2>
+    uninitialized_relocate_n(ExecutionPolicy&& exec,                              // freestanding-deleted, see [algorithms.parallel.overloads]
                              NoThrowForwardIterator1 first,
                              Size n,
                              NoThrowForwardIterator2 result);
@@ -558,8 +622,8 @@ template<class NoThrowBidirectionalIterator1, class NoThrowBidirectionalIterator
                                     NoThrowBidirectionalIterator2 result);
 
 template<class ExecutionPolicy, class NoThrowBidirectionalIterator1, class NoThrowBidirectionalIterator2>
-  constexpr NoThrowBidirectionalIterator2
-    uninitialized_relocate_backward(ExecutionPolicy&& exec,                       // see [algorithms.parallel.overloads]
+  NoThrowBidirectionalIterator2
+    uninitialized_relocate_backward(ExecutionPolicy&& exec,                       // freestanding-deleted, see [algorithms.parallel.overloads]
                                     NoThrowBidirectionalIterator1 first,
                                     NoThrowBidirectionalIterator1 last,
                                     NoThrowBidirectionalIterator2 result);
@@ -572,26 +636,26 @@ namespace ranges {
            @_nothrow-forward-iterator_@ O, @_nothrow-sentinel-for_@<O> S2>
     requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
       constexpr uninitialized_relocate_result<I, O>
-        uninitialized_relocate(I ifirst, S1 ilast, O ofirst, S2 olast);           // freestanding
+        uninitialized_relocate(I first, S1 last, O result, S2 result_last);       // freestanding
 
   template<@_execution-policy_@ Ep,
            @_nothrow-random-access-iterator_@ I, @_nothrow-sized-sentinel-for_@<I> S1,
            @_nothrow-random-access-iterator_@ O, @_nothrow-sized-sentinel-for_@<O> S2>
     requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
-      constexpr uninitialized_relocate_result<I, O>
-        uninitialized_relocate(Ep&& exec,                                         // see [algorithms.parallel.overloads]
-                               I ifirst, S1 ilast, O ofirst, S2 olast);
+      uninitialized_relocate_result<I, O>
+        uninitialized_relocate(Ep&& exec,                                         // freestanding-deleted, see [algorithms.parallel.overloads]
+                               I first, S1 last, O result, S2 result_last);
 
   template<@_nothrow-forward-range_@ IR, @_nothrow-forward-range_@<I> OR>,
     requires @_relocatable-from_@<range_value_t<IR>, range_value_t<OR>>
       constexpr uninitialized_relocate_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
-        uninitialized_relocate(IR&& in_range, OR&& out_range);                   // freestanding
+        uninitialized_relocate(IR&& r, OR&& result_r);                            // freestanding
 
   template<@_execution-policy_@ Ep, @_nothrow-random-access-range_@ IR, @_nothrow-random-access-range_@<I> OR>,
     requires @_relocatable-from_@<range_value_t<IR>, range_value_t<OR>>
-      constexpr uninitialized_relocate_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
-        uninitialized_relocate(Ep&& exec,                                         // see [algorithms.parallel.overloads]
-                               IR&& in_range, OR&& out_range);
+      uninitialized_relocate_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
+        uninitialized_relocate(Ep&& exec,                                         // freestanding-deleted, see [algorithms.parallel.overloads]
+                               IR&& r, OR&& result_r);
 
   template<class I, class O>
     using uninitialized_relocate_n_result = in_out_result<I, O>;                  // freestanding
@@ -600,15 +664,15 @@ namespace ranges {
            @_nothrow-forward-iterator_@ O, @_nothrow-sentinel-for_@<O> S>
     requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
       constexpr uninitialized_relocate_n_result<I, O>
-        uninitialized_relocate_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);  // freestanding
+        uninitialized_relocate_n(I first, iter_difference_t<I> n, O result, S result_last);  // freestanding
 
   template<@_execution-policy_@ Ep,
            @_nothrow-random-access-iterator_@ I,
            @_nothrow-random-access-iterator_@ O, @_nothrow-sized-sentinel-for_@<O> S>
     requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
-      constexpr uninitialized_relocate_n_result<I, O>
-        uninitialized_relocate_n(Ep&& exec,                                       // see [algorithms.parallel.overloads]
-                                 I ifirst, iter_difference_t<I> n, O ofirst, S olast);
+      uninitialized_relocate_n_result<I, O>
+        uninitialized_relocate_n(Ep&& exec,
+                                 I first, iter_difference_t<I> n, O result, S result_last); // freestanding-deleted, see [algorithms.parallel.overloads]
 
   template<class I, class O>
     using uninitialized_relocate_backward_result = in_out_result<I, O>;           // freestanding
@@ -617,26 +681,7 @@ namespace ranges {
            @_nothrow-bidirectional-iterator_@ O, @_nothrow-sentinel-for_@<O> S2>
     requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
       constexpr uninitialized_relocate_backward_result<I, O>
-        uninitialized_relocate_backward(I ifirst, S1 ilast, O ofirst, S2 olast);  // freestanding
-
-  template<@_execution-policy_@ Ep,
-           @_nothrow-random-access-iterator_@ I, @_nothrow-sized-sentinel-for_@<I> S1,
-           @_nothrow-random-access-iterator_@ O, @_nothrow-sized-sentinel-for_@<O> S2>
-    requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
-      constexpr uninitialized_relocate_backward_result<I, O>
-        uninitialized_relocate_backward(Ep&& exec,                                // see [algorithms.parallel.overloads]
-                                        I ifirst, S1 ilast, O ofirst, S2 olast);
-
-  template<@_nothrow-bidirectional-range_@ IR, @_nothrow-bidirectional-range_@ OR>
-    requires @_relocatable-from_@<range_value_t<IR>, range_value_t<OR>>
-      constexpr uninitialized_relocate_backward_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
-        uninitialized_relocate_backward(IR&& in_range, OR&& out_range);           // freestanding
-
-  template<@_execution-policy_@ Ep, @_nothrow-random-access-range_@ IR, @_nothrow-random-access-range_@ OR>
-    requires @_relocatable-from_@<range_value_t<IR>, range_value_t<OR>>
-      constexpr uninitialized_relocate_backward_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
-        uninitialized_relocate_backward(Ep&& exec,                                // see [algorithms.parallel.overloads]
-                                        IR&& in_range, OR&& out_range);
+        uninitialized_relocate_backward(I first, S1 last, O result_first, S2 result_last);  // freestanding
 }
 ```
 
@@ -653,33 +698,16 @@ template<class T>
     noexcept(is_nothrow_relocatable_v<T>);
 ```
 
-- [?]{.pnum} _Preconditions_: `dest` and `source` point to objects that are not potentially overlapping subobjects.
+- [?]{.pnum} _Preconditions_: Neither `*dest` nor `*source` is a potentially-overlapping subobject.
 
 - [?]{.pnum} _Effects_: Equivalent to:
 
 ```c++
 if (dest == source)
   return dest;
-if constexpr (is_trivially_relocatable_v<T> && is_move_constructible_v<T>) {
-  if consteval {
-    return @_relocate-via-move-and-destroy_@(dest, source);
-  } else {
-    return trivially_relocate(source, source + 1, dest);
-  }
-} else if constexpr (is_trivially_relocatable_v<T>) {
-  return trivially_relocate(source, source + 1, dest);
-} else {
-  return @_relocate-via-move-and-destroy_@(dest, source);
-}
+return @_relocate-via-move-and-destroy_@(dest, source);
 ```
 
-<!--
-TODO
-
-Design questions for relocate_at:
-- Should we spell out the prerequisites? 1. source != dest, 2. T is complete
-- Should it unconditionally destroy the source? For the single element relocate, there's a recovery option.
--->
 
 ### [uninitialized.relocate]
 
@@ -720,40 +748,88 @@ namespace ranges {
            @_nothrow-forward-iterator_@ O, @_nothrow-sentinel-for_@<O> S2>
     requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
       constexpr uninitialized_relocate_result<I, O>
-        uninitialized_relocate(I ifirst, S1 ilast, O ofirst, O2 olast);
+        uninitialized_relocate(I first, S1 last, O result, O2 result_last);
 
   template<@_nothrow-forward-range_@ IR, @_nothrow-forward-range_@<I> OR>,
     requires @_relocatable-from_@<range_value_t<IR>, range_value_t<OR>>
       constexpr uninitialized_relocate_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
-        uninitialized_relocate(IR&& in_range, OR&& out_range);
+        uninitialized_relocate(IR&& r, OR&& result_r);
 }
 ```
 
-- [?]{.pnum} _Preconditions_: `ofirst` is not in the range `[ifirst, ilast)`.
+- [?]{.pnum} _Preconditions_: `result` is not in the range `[first, last)`.
 
 - [?]{.pnum} _Effects_: Equivalent to:
 
 ```c++
-O first_result = ofirst;
+O first_result = result;
 try {
-  while (ifirst != ilast && ofirst != olast) {
-    relocate_at(addressof(*ofirst), addressof(*ifirst));
-    ++ifirst;
-    ++ofirst;
+  while (first != last && result != result_last) {
+    relocate_at(addressof(*result), addressof(*first));
+    ++first;
+    ++result;
   }
 } catch (...) {
-  destroy(first_result, ofirst);
-  ++ifirst;
-  while (ifirst != ilast && ofirst != olast) {
-    destroy_at(addressof(*ifirst));
-    ++ifirst;
-    ++ofirst;
+  destroy(first_result, result);
+  ++first;
+  while (first != last && result != result_last) {
+    destroy_at(addressof(*first));
+    ++first;
+    ++result;
   }
   throw;
 }
 
-return {std::move(ifirst), ofirst};
+return {std::move(ifirst), result};
 ```
+
+```c++
+template<class ExecutionPolicy, class NoThrowForwardIterator1, class NoThrowForwardIterator2>
+  constexpr NoThrowForwardIterator2
+    uninitialized_relocate(ExecutionPolicy&& exec,
+                           NoThrowForwardIterator1 first,
+                           NoThrowForwardIterator1 last,
+                           NoThrowForwardIterator2 result);
+
+namespace ranges {
+  template<@_execution-policy_@ Ep,
+           @_nothrow-random-access-iterator_@ I, @_nothrow-sized-sentinel-for_@<I> S1,
+           @_nothrow-random-access-iterator_@ O, @_nothrow-sized-sentinel-for_@<O> S2>
+    requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
+      uninitialized_relocate_result<I, O>
+        uninitialized_relocate(Ep&& exec,
+                               I first, S1 last, O result, S2 result_last);
+
+  template<@_nothrow-forward-range_@ IR, @_nothrow-forward-range_@<I> OR>,
+    requires @_relocatable-from_@<range_value_t<IR>, range_value_t<OR>>
+      constexpr uninitialized_relocate_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
+        uninitialized_relocate(IR&& r, OR&& result_r);
+
+  template<@_execution-policy_@ Ep, @_nothrow-random-access-range_@ IR, @_nothrow-random-access-range_@<I> OR>,
+    requires @_relocatable-from_@<range_value_t<IR>, range_value_t<OR>>
+      uninitialized_relocate_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
+        uninitialized_relocate(Ep&& exec,
+                               IR&& r, OR&& result_r);
+}
+```
+
+- [?]{.pnum} Let `result_last` be `result + (last - first)` for the overload in namespace `std`.
+
+- [?]{.pnum} Let *N* be `min(last - first, result_last - result)`.
+
+- [?]{.pnum} _Preconditions_: The ranges `[first, last)` and `[result, result + N)` do not overlap.
+
+- [?]{.pnum} _Effects_: Relocates elements in the range `[first, first + N)` into the range `[result, result + N)`.
+  For each non-negative integer *n* < *N*, performs `relocate_at(addressof(*(first + n)), addressof(*(result + n)))`.
+
+- [?]{.pnum} _Returns_:
+
+  - [?]{.pnum} `result + N` for the overload in namespace `std`.
+
+  - [?]{.pnum} `{first + N, result + N}` for the overloads in namespace `ranges`.
+
+- [?]{.pnum} _Complexity_: Exactly *N* relocations.
+
 
 
 ### [uninitialized.relocate_n]
@@ -769,6 +845,8 @@ template<class NoThrowForwardIterator1, class Size, class NoThrowForwardIterator
 ```
 
 - [?]{.pnum} _Preconditions_: `result` is not in the range `[first, first + n)`.
+
+- [?]{.pnum} _Mandates_: The type Size is convertible to an integral type ([conv.integral], [class.conv]).
 
 - [?]{.pnum} _Effects_: Equivalent to:
 
@@ -796,38 +874,74 @@ namespace ranges {
            @_nothrow-forward-iterator_@ O, @_nothrow-sentinel-for_@<O> S>
     requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
       constexpr uninitialized_relocate_n_result<I, O>
-        uninitialized_relocate_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
+        uninitialized_relocate_n(I first, iter_difference_t<I> n, O result, S result_last);
 }
 ```
 
-- [?]{.pnum} _Preconditions_: `ofirst` is not in the range `[ifirst, ifirst + n)`.
+- [?]{.pnum} _Preconditions_: `result` is not in the range `[first, first + n)`.
 
 - [?]{.pnum} _Effects_: Equivalent to:
 
 ```c++
-O first_result = ofirst;
+O first_result = result;
 try {
-  while (n > 0 && ofirst != olast) {
-    relocate_at(addressof(*ofirst), addressof(*ifirst));
-    ++ifirst;
-    ++ofirst;
+  while (n > 0 && result != result_last) {
+    relocate_at(addressof(*result), addressof(*first));
+    ++first;
+    ++result;
     --n;
   }
 } catch (...) {
-  destroy(first_result, ofirst);
-  ++ifirst;
+  destroy(first_result, result);
+  ++first;
   --n;
-  while (n > 0 && ofirst != olast) {
-    destroy_at(addressof(*ifirst));
-    ++ifirst;
-    ++ofirst;
+  while (n > 0 && result != result_last) {
+    destroy_at(addressof(*first));
+    ++first;
+    ++result;
     --n;
   }
   throw;
 }
 
-return {std::move(ifirst), ofirst};
+return {first, result};
 ```
+
+```c++
+template<class ExecutionPolicy, class NoThrowForwardIterator1, class Size, class NoThrowForwardIterator2>
+  constexpr pair<NoThrowForwardIterator1, NoThrowForwardIterator2>
+    uninitialized_relocate_n(ExecutionPolicy&& exec,
+                             NoThrowForwardIterator1 first,
+                             Size n,
+                             NoThrowForwardIterator2 result);
+
+namespace ranges {
+  template<@_execution-policy_@ Ep,
+           @_nothrow-random-access-iterator_@ I,
+           @_nothrow-random-access-iterator_@ O, @_nothrow-sized-sentinel-for_@<O> S>
+    requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
+      uninitialized_relocate_n_result<I, O>
+        uninitialized_relocate_n(Ep&& exec,
+                                 I first, iter_difference_t<I> n, O result, S result_last);
+}
+```
+
+- [?]{.pnum} Let *M* be `max(0, n)`.
+
+- [?]{.pnum} Let `result_last` be `result + M` for the overload in namespace `std`.
+
+- [?]{.pnum} Let *N* be `min(result_last - result, M)`.
+
+- [?]{.pnum} _Mandates_: The type `Size` is convertible to an integral type ([conv.integral]{.sref}, [class.conv]{.sref}).
+
+- [?]{.pnum} _Preconditions_: The ranges `[first, last)` and `[result, result + N)` do not overlap.
+
+- [?]{.pnum} _Effects_: Relocates elements in the range `[first, first + N)` into the range `[result, result + N)`.
+  For each non-negative integer *n* < *N*, performs `relocate_at(addressof(*(first + n)), addressof(*(result + n)))`.
+
+- [?]{.pnum} _Returns_: `{first + N, result + N}`.
+
+- [?]{.pnum} _Complexity_: Exactly *N* relocations.
 
 ### [uninitialized.relocate_backward]
 
@@ -869,39 +983,40 @@ namespace ranges {
            @_nothrow-bidirectional-iterator_@ O, @_nothrow-sentinel-for_@<O> S2>
     requires @_relocatable-from_@<iter_value_t<I>, iter_value_t<O>>
       constexpr uninitialized_relocate_backward_result<I, O>
-        uninitialized_relocate_backward(I ifirst, S1 ilast, O ofirst, S2 olast);
+        uninitialized_relocate_backward(I first, S1 last, O result, S2 result_last);
 
   template<@_nothrow-bidirectional-range_@ IR, @_nothrow-bidirectional-range_@ OR>
     requires @_relocatable-from_@<range_value_t<IR>, range_value_t<OR>>
       constexpr uninitialized_relocate_backward_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
-        uninitialized_relocate_backward(IR&& in_range, OR&& out_range);
+        uninitialized_relocate_backward(IR&& r, OR&& result_r);
 }
 ```
 
-- [?]{.pnum} _Preconditions_: `olast` is not in the range `(ifirst, ilast]`.
+- [?]{.pnum} _Preconditions_: `result_last` is not in the range `(first, last]`.
 
 - [?]{.pnum} _Effects_: Equivalent to:
 
 ```c++
-O result_last = olast;
+I last_ = ranges::next(first, last);
+O result_last_ = ranges::next(result, result_last);
+
 try {
-  while (ilast != ifirst && olast != ofirst) {
-    --ilast;
-    --olast;
-    relocate_at(addressof(*olast), addressof(*ilast));
+  while (last_ != first && result_last_ != result) {
+    --last_;
+    --result_last_;
+    relocate_at(addressof(*result_last_), addressof(*last_));
   }
 } catch (...) {
-  destroy(++olast, result_last);
-  --ilast;
-  while (ilast != ifirst && olast != ofirst) {
-    --ilast;
-    --olast;
-    destroy_at(addressof(*ilast));
+  ranges::destroy(ranges::next(result_last_), result_last);
+  while (last_ != first && result_last_ != result) {
+    --last_;
+    --result_last_;
+    destroy_at(addressof(*last_));
   }
   throw;
 }
 
-return {ilast, olast};
+return {last_, result_last_};
 ```
 
 # Acknowledgements


### PR DESCRIPTION
This is an update of P3516 (algorithms for relocation), after the removal of trivial relocation from C++26. It's mostly a rebase on the latest draft.

The design is the same, and so the motivation: the algorithm are generic building blocks; calling code simply wants object to be relocated in memory, without having to care about _how_ that operation is implemented (move-and-destroy, trivial relocation in the future, ...).

Changes:

* Adapt the intro to the current status (P2786 reverted).
* Remark that we still want algorithms based on relocate_at, even if right now it's just a move+destroy wrapper.
* Reintroduce is_nothrow_relocatable, which was part of P2786.
* Change the implementation of relocate_at / relocatable_from.
* Change the synopsis of the algorithms (after the range-parallel merge).
* Specify the parallel relocate / relocate_n, again following the precedent.
* Drop the parallel relocate_backward. There's no equivalent in the copy/move algorithms, and the reason for that is that the parallel versions have a more stringent non-overlapping precondition: any overlap is forbidden. Therefore, there's no need of a backward version.
* Misc parameter / implementation renaming, matching the current draft (esp. copy and copy_backward).
* Redo the implementation of the ranges::uninitialized_relocate_backward, which needs to produce an iterator from the end sentinel (so it has to use ranges::next, it can't just walk backwards _from the sentinel_).